### PR TITLE
fix(auth): use cookie storage for iOS PWA session persistence

### DIFF
--- a/.claude/agents/issue-worker.md
+++ b/.claude/agents/issue-worker.md
@@ -1,0 +1,1 @@
+../web-agentic/agents/issue-worker.md

--- a/issues/000-backlog.md
+++ b/issues/000-backlog.md
@@ -2,6 +2,7 @@
 
 | # | Title | Status | Link |
 |---|-------|--------|------|
+| 068 | PWA iOS: Session not persisted when app is added to home screen | `pending` | [#68](https://github.com/handharr-labs/xpnsio/issues/68) |
 | 066 | Architecture violations fix: BudgetOverviewCard logic divergence, ViewModel mutable state, onboarding route guard, AuthDbDataSource rename | `pending` | [#66](https://github.com/handharr-labs/xpnsio/issues/66) |
 | 064 | fix: architecture violations - entity immutability, usecase bypasses, and layer boundary breaches | `pending` | [#64](https://github.com/handharr-labs/xpnsio/issues/64) |
 | 062 | Fix PWA session not persisting after app kill by adding missing middleware.ts | `pending` | [#62](https://github.com/handharr-labs/xpnsio/issues/62) |

--- a/src/features/auth/data/data-sources/auth/AuthRemoteDataSourceImpl.ts
+++ b/src/features/auth/data/data-sources/auth/AuthRemoteDataSourceImpl.ts
@@ -1,12 +1,9 @@
-import { createBrowserClient } from '@supabase/ssr';
+import { createSupabaseBrowserClient } from '@/lib/supabase-browser';
 import type { AuthRemoteDataSource } from './AuthRemoteDataSource';
 import type { AuthUserRecord } from './AuthUserRecord';
 
 export class AuthRemoteDataSourceImpl implements AuthRemoteDataSource {
-  private readonly supabase = createBrowserClient(
-    process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
-  );
+  private readonly supabase = createSupabaseBrowserClient();
 
   constructor(private readonly redirectOrigin: string) {}
 

--- a/src/lib/supabase-browser.ts
+++ b/src/lib/supabase-browser.ts
@@ -1,8 +1,49 @@
 import { createBrowserClient } from '@supabase/ssr';
 
+/**
+ * Cookie-based storage adapter for the browser Supabase client.
+ *
+ * iOS Safari in PWA standalone mode does NOT persist localStorage between
+ * app launches — it is cleared when the user closes the app. Cookies ARE
+ * persisted. By pointing createBrowserClient at document.cookie we ensure
+ * the session survives PWA relaunches on iPhone.
+ *
+ * The server-side client (src/lib/auth.ts) and middleware.ts already read
+ * cookies, so this makes the client side consistent with the server side.
+ */
+function getCookieStorage() {
+  return {
+    getItem(key: string): string | null {
+      if (typeof document === 'undefined') return null;
+      const match = document.cookie
+        .split('; ')
+        .find((row) => row.startsWith(`${key}=`));
+      return match
+        ? decodeURIComponent(match.split('=').slice(1).join('='))
+        : null;
+    },
+    setItem(key: string, value: string): void {
+      if (typeof document === 'undefined') return;
+      // 400 days — same lifetime Supabase uses for refresh tokens
+      const maxAge = 60 * 60 * 24 * 400;
+      document.cookie = `${key}=${encodeURIComponent(value)}; path=/; max-age=${maxAge}; SameSite=Lax; Secure`;
+    },
+    removeItem(key: string): void {
+      if (typeof document === 'undefined') return;
+      document.cookie = `${key}=; path=/; max-age=0; SameSite=Lax; Secure`;
+    },
+  };
+}
+
 export function createSupabaseBrowserClient() {
   return createBrowserClient(
     process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    {
+      auth: {
+        storage: getCookieStorage(),
+        persistSession: true,
+      },
+    }
   );
 }


### PR DESCRIPTION
Closes #68

## Summary
- iOS Safari in PWA standalone mode wipes `localStorage` when the app is closed — sessions were lost on every relaunch
- Added a `document.cookie` storage adapter to `createSupabaseBrowserClient()` so tokens survive PWA relaunches on iPhone
- Removed duplicate inline `createBrowserClient()` in `AuthRemoteDataSourceImpl` — now uses the shared factory

## Root cause
The browser Supabase client defaulted to `localStorage`. The server-side client and middleware already read from cookies, so client and server were out of sync on iOS PWA.

## Test plan
- [ ] Add app to iPhone home screen, sign in with Google
- [ ] Close the app fully and reopen — should stay logged in
- [ ] Sign out — should redirect to login
- [ ] Normal browser flow (non-PWA) still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)