### PR TITLE
fix(auth): revert custom cookie adapter — use createBrowserClient defaults for iOS PWA

### DIFF
--- a/src/lib/supabase-browser.ts
+++ b/src/lib/supabase-browser.ts
@@ -1,49 +1,8 @@
 import { createBrowserClient } from '@supabase/ssr';
 
-/**
- * Cookie-based storage adapter for the browser Supabase client.
- *
- * iOS Safari in PWA standalone mode does NOT persist localStorage between
- * app launches — it is cleared when the user closes the app. Cookies ARE
- * persisted. By pointing createBrowserClient at document.cookie we ensure
- * the session survives PWA relaunches on iPhone.
- *
- * The server-side client (src/lib/auth.ts) and middleware.ts already read
- * cookies, so this makes the client side consistent with the server side.
- */
-function getCookieStorage() {
-  return {
-    getItem(key: string): string | null {
-      if (typeof document === 'undefined') return null;
-      const match = document.cookie
-        .split('; ')
-        .find((row) => row.startsWith(`${key}=`));
-      return match
-        ? decodeURIComponent(match.split('=').slice(1).join('='))
-        : null;
-    },
-    setItem(key: string, value: string): void {
-      if (typeof document === 'undefined') return;
-      // 400 days — same lifetime Supabase uses for refresh tokens
-      const maxAge = 60 * 60 * 24 * 400;
-      document.cookie = `${key}=${encodeURIComponent(value)}; path=/; max-age=${maxAge}; SameSite=Lax; Secure`;
-    },
-    removeItem(key: string): void {
-      if (typeof document === 'undefined') return;
-      document.cookie = `${key}=; path=/; max-age=0; SameSite=Lax; Secure`;
-    },
-  };
-}
-
 export function createSupabaseBrowserClient() {
   return createBrowserClient(
     process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
-    {
-      auth: {
-        storage: getCookieStorage(),
-        persistSession: true,
-      },
-    }
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
   );
 }


### PR DESCRIPTION
Closes #68

## What went wrong with the previous fix (#69)
The custom `document.cookie` storage adapter used the raw localStorage key (`sb-<ref>-auth-token`) as the cookie name. But `@supabase/ssr`'s `createServerClient` reads **chunked** cookies named `sb-<ref>-auth-token.0`, `.1`, etc. Middleware saw no recognizable cookie and immediately redirected to login — explaining the instant redirect with no flash.

## Root cause
`createBrowserClient` and `createServerClient` from `@supabase/ssr` share a chunked-cookie contract. Injecting a custom `auth.storage` adapter breaks that contract. The auth callback route already emits persistent `Set-Cookie` headers (HttpOnly) via `exchangeCodeForSession` — this is what middleware reads. The browser client does not need to manage cookie persistence at all.

## Fix
Removed the custom `auth.storage` adapter. `createBrowserClient` from `@supabase/ssr` uses the same chunked-cookie scheme as `createServerClient` by default — no override needed.

## Test plan
- [ ] Add app to iPhone home screen, sign in with Google
- [ ] Close the app fully and reopen — should stay logged in (no redirect to login)
- [ ] Sign out — should redirect to login
- [ ] Normal browser (non-PWA) flow still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)