### PR TITLE
fix(auth): forward refreshed session cookies on middleware redirects

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -32,7 +32,11 @@ export async function middleware(request: NextRequest) {
   if (pathname === '/') {
     const url = request.nextUrl.clone();
     url.pathname = user ? '/dashboard' : '/login';
-    return NextResponse.redirect(url);
+    const redirectResponse = NextResponse.redirect(url);
+    supabaseResponse.cookies.getAll().forEach((cookie) =>
+      redirectResponse.cookies.set(cookie.name, cookie.value, cookie)
+    );
+    return redirectResponse;
   }
 
   // Redirect unauthenticated users away from protected routes
@@ -41,7 +45,11 @@ export async function middleware(request: NextRequest) {
   if (!user && isProtected) {
     const url = request.nextUrl.clone();
     url.pathname = '/login';
-    return NextResponse.redirect(url);
+    const redirectResponse = NextResponse.redirect(url);
+    supabaseResponse.cookies.getAll().forEach((cookie) =>
+      redirectResponse.cookies.set(cookie.name, cookie.value, cookie)
+    );
+    return redirectResponse;
   }
 
   return supabaseResponse;


### PR DESCRIPTION
Closes #68

## Root cause (third attempt — the real one)
`NextResponse.redirect()` creates a brand-new response. The refreshed tokens written into `supabaseResponse` by `supabase.auth.getUser()` were being silently dropped on every middleware redirect (`/` → `/dashboard`, protected route → `/login`).

On desktop this was masked by client-side Supabase auto-refresh running in the background. On iOS PWA after force-quit there is no running JS — the app relies entirely on the middleware cookie chain. Dropped tokens caused every relaunch to see an expired access token and immediately redirect to login.

## Fix
Copy all cookies from `supabaseResponse` into each `NextResponse.redirect()` so refreshed tokens survive the redirect and are persisted by the browser.

## Why the previous fixes didn't work
- **#69** — added a custom `document.cookie` storage adapter to the browser client (wrong layer, wrong cookie names)
- **#70** — reverted that adapter (correct, but didn't address the middleware redirect bug)

## Test plan
- [ ] Add app to iPhone home screen, sign in with Google
- [ ] Close the app fully and reopen — should stay logged in
- [ ] Wait >1 hour, reopen — should still be logged in (refresh token kicks in via middleware)
- [ ] Sign out — should redirect to login
- [ ] Desktop browser flow unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)