### PR TITLE
fix(css): add Tailwind v4 @source directive and Base UI position utilities for prod build

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -2,6 +2,14 @@
 @import "tw-animate-css";
 @import "shadcn/tailwind.css";
 
+/*
+ * Explicit source scanning for the webpack/PostCSS production build.
+ * `next dev` uses Turbopack which generates all Tailwind classes on-the-fly.
+ * `next build --webpack` uses @tailwindcss/postcss which statically scans files;
+ * without these directives it may only scan src/app/ and miss the rest of the src tree.
+ */
+@source "../**/*.{tsx,ts,jsx,js}";
+
 @custom-variant dark (&:is(.dark *));
 
 @theme inline {
@@ -135,3 +143,13 @@
     font-size: 16px !important;
   }
 }
+
+/*
+ * Base UI Select (@base-ui/react) uses CSS variables set inline by its Positioner component.
+ * Tailwind v4's PostCSS scanner may not recognise the `(--var-name)` arbitrary-value syntax
+ * as class names, so these utilities are defined explicitly as plain CSS rules to guarantee
+ * they survive the webpack/LightningCSS production build.
+ */
+.w-\(--anchor-width\)         { width: var(--anchor-width); }
+.max-h-\(--available-height\) { max-height: var(--available-height); }
+.origin-\(--transform-origin\) { transform-origin: var(--transform-origin); }


### PR DESCRIPTION
## Summary

- Adds `@source "../**/*.{tsx,ts,jsx,js}"` to `globals.css` so `@tailwindcss/postcss` scans the full `src/` tree in webpack production builds
- Adds explicit CSS rules for Base UI Select's CSS-variable-based utilities (`w-(--anchor-width)`, `max-h-(--available-height)`, `origin-(--transform-origin)`) that the Tailwind scanner doesn't recognise

## Root Cause

`next dev` uses **Turbopack** (generates all CSS on-the-fly — always works). `next build --webpack` uses `@tailwindcss/postcss` which statically scans files. Without an explicit `@source` directive it only scanned `src/app/`, missing all utilities used in `src/features/` and `src/components/`, causing prod-only breakage of:

- `grid-cols-3` → "How to split?" buttons were stacked vertically
- `sm:max-w-md` / `sm:items-center` → New Trip modal was full-screen on desktop
- `bg-primary/10`, `rounded-md`, etc. → "Me" badge rendered broken
- `w-(--anchor-width)` etc. → Base UI Select dropdown was mispositioned

## Test plan

- [ ] `npm run build && npm start` — does NOT reproduce any of the 4 reported prod bugs
- [ ] `npm run dev` — still works as expected (baseline unchanged)

Closes #78

🤖 Generated with [Claude Code](https://claude.com/claude-code)