### PR TITLE
fix(trips+split-bill): UX improvements — bank accounts, bill picker, sort order

### DIFF
--- a/issues/000-backlog.md
+++ b/issues/000-backlog.md
@@ -2,6 +2,7 @@
 
 | # | Title | Status | Link |
 |---|-------|--------|------|
+| 077 | fix(trips): UX improvements for trip & split bill features | `pending` | [#77](https://github.com/handharr-labs/xpnsio/issues/77) |
 | 075 | Include creator as optional participant in split bill | `pending` | [#75](https://github.com/handharr-labs/xpnsio/issues/75) |
 | 073 | feat: split bill MVP | `pending` | [#73](https://github.com/handharr-labs/xpnsio/issues/73) |
 | 068 | PWA iOS: Session not persisted when app is added to home screen | `pending` | [#68](https://github.com/handharr-labs/xpnsio/issues/68) |

--- a/src/features/split-bill/data/data-sources/SplitBillDbDataSource.ts
+++ b/src/features/split-bill/data/data-sources/SplitBillDbDataSource.ts
@@ -48,6 +48,7 @@ export interface UpdateBillDataParams {
 export interface SplitBillDbDataSource {
   findById(id: string): Promise<SplitBillDetailRecord | null>;
   findByUserId(userId: string): Promise<SplitBillRow[]>;
+  findStandaloneByUserId(userId: string): Promise<SplitBillRow[]>;
   createBill(params: CreateBillDataParams): Promise<SplitBillDetailRecord>;
   updateBill(params: UpdateBillDataParams): Promise<void>;
   deleteBill(billId: string): Promise<void>;

--- a/src/features/split-bill/data/data-sources/SplitBillDbDataSourceImpl.ts
+++ b/src/features/split-bill/data/data-sources/SplitBillDbDataSourceImpl.ts
@@ -1,4 +1,4 @@
-import { and, eq, inArray, notInArray, or } from 'drizzle-orm';
+import { and, desc, eq, inArray, isNull, notInArray, or } from 'drizzle-orm';
 import { db } from '@/lib/db';
 import {
   splitBills,
@@ -63,7 +63,15 @@ export class SplitBillDbDataSourceImpl implements SplitBillDbDataSource {
       .select()
       .from(splitBills)
       .where(eq(splitBills.userId, userId))
-      .orderBy(splitBills.createdAt);
+      .orderBy(desc(splitBills.createdAt));
+  }
+
+  async findStandaloneByUserId(userId: string): Promise<SplitBillRow[]> {
+    return db
+      .select()
+      .from(splitBills)
+      .where(and(eq(splitBills.userId, userId), isNull(splitBills.tripId)))
+      .orderBy(desc(splitBills.createdAt));
   }
 
   async createBill(params: CreateBillDataParams): Promise<SplitBillDetailRecord> {

--- a/src/features/split-bill/data/repositories/SplitBillRepositoryImpl.ts
+++ b/src/features/split-bill/data/repositories/SplitBillRepositoryImpl.ts
@@ -29,6 +29,15 @@ export class SplitBillRepositoryImpl implements SplitBillRepository {
     }
   }
 
+  async getStandaloneByUserId(userId: string): Promise<SplitBill[]> {
+    try {
+      const rows = await this.dataSource.findStandaloneByUserId(userId);
+      return rows.map((r) => this.mapper.toBill(r));
+    } catch (error) {
+      throw DomainError.serverError(String(error));
+    }
+  }
+
   async create(params: CreateSplitBillParams): Promise<SplitBillDetail> {
     try {
       const record = await this.dataSource.createBill({

--- a/src/features/split-bill/domain/repositories/SplitBillRepository.ts
+++ b/src/features/split-bill/domain/repositories/SplitBillRepository.ts
@@ -42,6 +42,7 @@ export interface UpdateSplitBillParams {
 export interface SplitBillRepository {
   getById(id: string): Promise<SplitBillDetail | null>;
   getByUserId(userId: string): Promise<SplitBill[]>;
+  getStandaloneByUserId(userId: string): Promise<SplitBill[]>;
   create(params: CreateSplitBillParams): Promise<SplitBillDetail>;
   update(params: UpdateSplitBillParams): Promise<void>;
   delete(billId: string): Promise<void>;

--- a/src/features/trips/presentation/actions/trips.ts
+++ b/src/features/trips/presentation/actions/trips.ts
@@ -1,8 +1,11 @@
 'use server';
 
 import { z } from 'zod';
+import { and, eq, isNull, desc } from 'drizzle-orm';
 import { authActionClient, actionClient } from '@/lib/safe-action';
 import { createServerContainer } from '@/shared/di/container.server';
+import { db } from '@/lib/db';
+import { splitBills } from '@/lib/schema';
 
 // ─── Create Trip ────────────────────────────────────────────────────────────
 
@@ -119,4 +122,17 @@ export const updateTripSettlementStatusAction = authActionClient
       status: parsedInput.status,
       userId: user.id,
     });
+  });
+
+// ─── Get Standalone Bills (auth) ─────────────────────────────────────────────
+
+export const getStandaloneBillsAction = authActionClient
+  .schema(z.object({}))
+  .action(async ({ ctx: { user } }) => {
+    const rows = await db
+      .select({ id: splitBills.id, title: splitBills.title, date: splitBills.date })
+      .from(splitBills)
+      .where(and(eq(splitBills.userId, user.id), isNull(splitBills.tripId)))
+      .orderBy(desc(splitBills.createdAt));
+    return rows;
   });

--- a/src/features/trips/presentation/views/TripDetailView.tsx
+++ b/src/features/trips/presentation/views/TripDetailView.tsx
@@ -1,10 +1,11 @@
 'use client';
 
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { useRouter } from 'next/navigation';
 import { ArrowLeft, Copy, Check, ExternalLink, ImageIcon, Plus, Trash2 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { useTripDetailViewModel } from '../state/useTripDetailViewModel';
+import { getStandaloneBillsAction } from '../actions/trips';
 import { formatCurrency } from '@/shared/presentation/utils/formatCurrency';
 import { ROUTES } from '@/shared/presentation/navigation/routes';
 import type { SettlementStatus } from '../../domain/entities/TripParticipantSettlement';
@@ -39,7 +40,9 @@ export function TripDetailView({ tripId }: { tripId: string }) {
 
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
   const [showAddBills, setShowAddBills] = useState(false);
-  const [addBillIdsInput, setAddBillIdsInput] = useState('');
+  const [standaloneBills, setStandaloneBills] = useState<{ id: string; title: string; date: string }[]>([]);
+  const [selectedBillIds, setSelectedBillIds] = useState<string[]>([]);
+  const [isFetchingBills, setIsFetchingBills] = useState(false);
   const [proofModal, setProofModal] = useState<string | null>(null);
   const [copiedLink, setCopiedLink] = useState(false);
 
@@ -60,15 +63,32 @@ export function TripDetailView({ tripId }: { tripId: string }) {
       )
     : 0;
 
+  useEffect(() => {
+    if (!showAddBills) {
+      setStandaloneBills([]);
+      setSelectedBillIds([]);
+      return;
+    }
+    setIsFetchingBills(true);
+    getStandaloneBillsAction({})
+      .then((res) => {
+        setStandaloneBills(res?.data ?? []);
+        setIsFetchingBills(false);
+      })
+      .catch(() => setIsFetchingBills(false));
+  }, [showAddBills]);
+
+  const toggleBill = (id: string) => {
+    setSelectedBillIds((prev) =>
+      prev.includes(id) ? prev.filter((x) => x !== id) : [...prev, id]
+    );
+  };
+
   const handleAddBillsSubmit = async () => {
-    const ids = addBillIdsInput
-      .split(',')
-      .map((s) => s.trim())
-      .filter(Boolean);
-    if (ids.length === 0) return;
-    await addBills(ids);
+    if (selectedBillIds.length === 0) return;
+    await addBills(selectedBillIds);
     setShowAddBills(false);
-    setAddBillIdsInput('');
+    setSelectedBillIds([]);
   };
 
   if (isLoading) {
@@ -282,37 +302,60 @@ export function TripDetailView({ tripId }: { tripId: string }) {
       {/* Add Bills dialog */}
       {showAddBills && (
         <div
-          className="fixed inset-0 bg-black/60 z-50 flex items-end sm:items-center justify-center p-0 sm:p-4"
+          className='fixed inset-0 bg-black/60 z-50 flex items-end sm:items-center justify-center p-0 sm:p-4'
           onClick={() => setShowAddBills(false)}
         >
           <div
-            className="bg-background w-full sm:max-w-md rounded-t-2xl sm:rounded-2xl p-5 space-y-4"
+            className='bg-background w-full sm:max-w-md rounded-t-2xl sm:rounded-2xl p-5 space-y-4'
             onClick={(e) => e.stopPropagation()}
           >
-            <h2 className="font-bold text-lg">Add Bills to Trip</h2>
-            <p className="text-sm text-muted-foreground">
-              Enter the bill IDs (comma-separated) of standalone bills to add to this trip.
+            <h2 className='font-bold text-lg'>Add Bills to Trip</h2>
+            <p className='text-sm text-muted-foreground'>
+              Select standalone bills to add to this trip.
             </p>
-            <textarea
-              className="w-full h-24 px-4 py-3 rounded-xl bg-muted/50 ring-1 ring-border text-sm placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-primary/50 resize-none"
-              placeholder="bill-uuid-1, bill-uuid-2"
-              value={addBillIdsInput}
-              onChange={(e) => setAddBillIdsInput(e.target.value)}
-            />
-            <div className="flex gap-2">
+            <div className='max-h-72 overflow-y-auto space-y-2'>
+              {isFetchingBills && (
+                <p className='text-sm text-muted-foreground text-center py-4'>Loading...</p>
+              )}
+              {!isFetchingBills && standaloneBills.length === 0 && (
+                <p className='text-sm text-muted-foreground text-center py-4'>No standalone bills available.</p>
+              )}
+              {!isFetchingBills && standaloneBills.map((bill) => {
+                const isSelected = selectedBillIds.includes(bill.id);
+                return (
+                  <div
+                    key={bill.id}
+                    onClick={() => toggleBill(bill.id)}
+                    className={`cursor-pointer flex items-center gap-3 p-3 rounded-xl ring-1 hover:bg-muted/50 transition-colors ${isSelected ? 'ring-primary/50 bg-primary/5' : 'ring-border'}`}
+                  >
+                    <input
+                      type='checkbox'
+                      readOnly
+                      checked={isSelected}
+                      className='w-4 h-4 accent-primary'
+                    />
+                    <div className='flex-1 min-w-0'>
+                      <p className='text-sm font-medium truncate'>{bill.title}</p>
+                      <p className='text-xs text-muted-foreground'>{bill.date}</p>
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+            <div className='flex gap-2'>
               <Button
-                variant="outline"
-                className="flex-1 rounded-xl"
+                variant='outline'
+                className='flex-1 rounded-xl'
                 onClick={() => setShowAddBills(false)}
               >
                 Cancel
               </Button>
               <Button
-                className="flex-1 rounded-xl"
-                disabled={isAddingBills || !addBillIdsInput.trim()}
+                className='flex-1 rounded-xl'
+                disabled={isAddingBills || selectedBillIds.length === 0}
                 onClick={handleAddBillsSubmit}
               >
-                {isAddingBills ? 'Adding…' : 'Add Bills'}
+                {isAddingBills ? 'Adding...' : `Add ${selectedBillIds.length > 0 ? selectedBillIds.length + ' ' : ''}Bill${selectedBillIds.length !== 1 ? 's' : ''}`}
               </Button>
             </div>
           </div>

--- a/src/features/trips/presentation/views/TripPublicView.tsx
+++ b/src/features/trips/presentation/views/TripPublicView.tsx
@@ -3,7 +3,7 @@
 import { useState, useRef } from 'react';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { useAction } from 'next-safe-action/hooks';
-import { Upload, X, ImageIcon, Check } from 'lucide-react';
+import { Upload, X, ImageIcon, Check, Copy } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { getTripDetailPublicAction, uploadTripSettlementProofAction } from '../actions/trips';
 import { formatCurrency } from '@/shared/presentation/utils/formatCurrency';
@@ -34,7 +34,14 @@ export function TripPublicView({ tripId }: { tripId: string }) {
   const [proofPreview, setProofPreview] = useState<string | null>(null);
   const [uploadError, setUploadError] = useState<string | null>(null);
   const [localError, setLocalError] = useState<string | null>(null);
+  const [copiedAccount, setCopiedAccount] = useState<string | null>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const copyAccount = (accountNumber: string, id: string) => {
+    navigator.clipboard.writeText(accountNumber);
+    setCopiedAccount(id);
+    setTimeout(() => setCopiedAccount(null), 2000);
+  };
 
   const { data: tripDetail, isLoading } = useQuery({
     queryKey: ['trip-public', tripId],
@@ -138,14 +145,36 @@ export function TripPublicView({ tripId }: { tripId: string }) {
 
           {/* Bills summary */}
           {bills.length > 0 && (
-            <div className="rounded-2xl bg-muted/50 ring-1 ring-border p-4 space-y-2">
-              <p className="text-sm font-semibold">Bills in this trip</p>
+            <div className='space-y-3'>
+              <p className='text-sm font-semibold'>Bills in this trip</p>
               {bills.map((bill) => {
                 const billTotal = bill.participants.reduce((s, p) => s + p.finalAmount, 0);
                 return (
-                  <div key={bill.id} className="flex items-center justify-between text-sm">
-                    <span className="text-muted-foreground truncate">{bill.title}</span>
-                    <span className="font-medium ml-2">{formatCurrency(billTotal, 'IDR')}</span>
+                  <div key={bill.id} className='rounded-2xl bg-muted/50 ring-1 ring-border p-4 space-y-3'>
+                    <div className='flex items-center justify-between text-sm'>
+                      <span className='font-medium truncate'>{bill.title}</span>
+                      <span className='font-semibold ml-2'>{formatCurrency(billTotal, 'IDR')}</span>
+                    </div>
+                    {bill.accounts.length > 0 && (
+                      <div className='space-y-2'>
+                        <p className='text-xs font-semibold text-muted-foreground'>Pay to</p>
+                        {bill.accounts.map((acc) => (
+                          <div key={acc.id} className='flex items-center justify-between'>
+                            <div>
+                              <p className='text-sm font-medium'>{acc.bankName}</p>
+                              <p className='font-mono text-sm'>{acc.accountNumber}</p>
+                            </div>
+                            <button
+                              onClick={() => copyAccount(acc.accountNumber, acc.id)}
+                              className='flex items-center gap-1.5 text-xs font-medium text-primary hover:underline min-h-[44px] px-2'
+                            >
+                              {copiedAccount === acc.id ? <Check className='w-4 h-4' /> : <Copy className='w-4 h-4' />}
+                              {copiedAccount === acc.id ? 'Copied!' : 'Copy'}
+                            </button>
+                          </div>
+                        ))}
+                      </div>
+                    )}
                   </div>
                 );
               })}


### PR DESCRIPTION
## Summary

- Sort bill list newest-first
- Show payment bank accounts on trip settlement public link
- Replace raw bill ID text input with a picker dialog when adding bills to a trip

## Commits

**`fix(split-bill): sort bill list by latest first`**
`SplitBillDbDataSourceImpl` — `orderBy(createdAt)` → `orderBy(desc(createdAt))`

**`feat(trips): show payment accounts on trip settlement public link`**
`TripPublicView` — adds a "Pay to" section per bill with bank name, monospace account number, and copy button, matching the standalone bill settlement view.

**`feat(trips): replace raw bill ID input with a bill picker dialog`**
- Data: `findStandaloneByUserId` (bills where `tripId IS NULL`) added to data source, repository interface, and repository impl
- Server action: `getStandaloneBillsAction` fetches the user's standalone bills
- UI: `TripDetailView` Add Bills dialog renders a scrollable checkbox list of standalone bills instead of a text input

## Test plan

- [ ] `/split-bill` — newest bill appears at the top
- [ ] Trip settlement public link (`/trip/[id]`) — each bill shows bank accounts with copy buttons
- [ ] Trip detail → Add Bills — opens a dialog listing unassigned bills with checkboxes; selecting and confirming adds them to the trip

Closes #77

🤖 Generated with [Claude Code](https://claude.com/claude-code)