### PR TITLE
fix(mobile): UI bugs in Split Bill and Trip features (#83)

### DIFF
--- a/issues/000-backlog.md
+++ b/issues/000-backlog.md
@@ -2,6 +2,7 @@
 
 | # | Title | Status | Link |
 |---|-------|--------|------|
+| 083 | fix(mobile): UI bugs in Split Bill and Trip features | `pending` | [#83](https://github.com/handharr-labs/xpnsio/issues/83) |
 | 081 | fix(trips): settlement UX improvements — merge payment accounts, save bank accounts to DB, replace 'You' with user name | `pending` | [#81](https://github.com/handharr-labs/xpnsio/issues/81) |
 | 077 | fix(trips): UX improvements for trip & split bill features | `pending` | [#77](https://github.com/handharr-labs/xpnsio/issues/77) |
 | 075 | Include creator as optional participant in split bill | `pending` | [#75](https://github.com/handharr-labs/xpnsio/issues/75) |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "xpnsio",
-  "version": "2.3.0",
+  "version": "2.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "xpnsio",
-      "version": "2.3.0",
+      "version": "2.5.0",
       "dependencies": {
         "@base-ui/react": "^1.2.0",
         "@ducanh2912/next-pwa": "10.2.9",

--- a/src/features/split-bill/presentation/SplitBillListView.tsx
+++ b/src/features/split-bill/presentation/SplitBillListView.tsx
@@ -44,7 +44,7 @@ export function SplitBillListView() {
         {isLoading && (
           <div className="space-y-3">
             {[1, 2, 3].map((i) => (
-              <div key={i} className="h-20 rounded-2xl bg-muted animate-pulse" />
+              <div key={i} className="h-20 w-full rounded-2xl bg-muted animate-pulse" />
             ))}
           </div>
         )}

--- a/src/features/split-bill/presentation/SplitBillManageView.tsx
+++ b/src/features/split-bill/presentation/SplitBillManageView.tsx
@@ -1,13 +1,17 @@
 'use client';
 
 import { useRouter } from 'next/navigation';
-import { ArrowLeft, Copy, Check, ExternalLink, ImageIcon, Pencil, Trash2 } from 'lucide-react';
+import { ArrowLeft, ImageIcon, Pencil, Trash2 } from 'lucide-react';
 import { useState } from 'react';
-import { Button } from '@/components/ui/button';
 import { useSplitBillManageViewModel } from './useSplitBillManageViewModel';
 import { formatCurrency } from '@/shared/presentation/utils/formatCurrency';
 import { ROUTES } from '@/shared/presentation/navigation/routes';
 import type { ParticipantStatus } from '../domain/entities/SplitBillParticipant';
+import { ShareLinkRow } from '@/shared/presentation/common/organisms/ShareLinkRow';
+import { PaymentAccountItem } from '@/shared/presentation/common/organisms/PaymentAccountItem';
+import { ProofImageModal } from '@/shared/presentation/common/organisms/ProofImageModal';
+import { DeleteConfirmDialog } from '@/shared/presentation/common/organisms/DeleteConfirmDialog';
+import { ProofActionsRow } from '@/shared/presentation/common/organisms/ProofActionsRow';
 
 const STATUS_STYLES: Record<ParticipantStatus, string> = {
   pending: 'bg-muted text-muted-foreground',
@@ -27,8 +31,6 @@ export function SplitBillManageView({ billId }: { billId: string }) {
   const router = useRouter();
   const { bill, isLoading, isUpdating, isDeleting, error, approveParticipant, rejectParticipant, deleteBillById } =
     useSplitBillManageViewModel(billId);
-  const [copiedAccount, setCopiedAccount] = useState<string | null>(null);
-  const [copiedLink, setCopiedLink] = useState(false);
   const [proofModal, setProofModal] = useState<string | null>(null);
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
 
@@ -36,24 +38,12 @@ export function SplitBillManageView({ billId }: { billId: string }) {
     ? `${window.location.origin}${ROUTES.splitBillPublic(billId)}`
     : '';
 
-  const copyAccount = (text: string, id: string) => {
-    navigator.clipboard.writeText(text);
-    setCopiedAccount(id);
-    setTimeout(() => setCopiedAccount(null), 2000);
-  };
-
-  const copyLink = () => {
-    navigator.clipboard.writeText(publicUrl);
-    setCopiedLink(true);
-    setTimeout(() => setCopiedLink(false), 2000);
-  };
-
   if (isLoading) {
     return (
-      <main className="min-h-screen px-4 pt-4 max-w-lg mx-auto">
+      <main className="px-4 pt-4 pb-8 max-w-lg mx-auto">
         <div className="h-8 w-48 bg-muted rounded-xl animate-pulse mb-4" />
         <div className="space-y-3">
-          {[1, 2, 3].map((i) => <div key={i} className="h-24 rounded-2xl bg-muted animate-pulse" />)}
+          {[1, 2, 3].map((i) => <div key={i} className="h-24 w-full rounded-2xl bg-muted animate-pulse" />)}
         </div>
       </main>
     );
@@ -105,49 +95,21 @@ export function SplitBillManageView({ billId }: { billId: string }) {
         )}
 
         {/* Share link */}
-        <div className="rounded-2xl bg-muted/50 ring-1 ring-border p-4 space-y-2">
-          <p className="text-sm font-medium">Share with participants</p>
-          <div className="flex gap-2">
-            <input
-              readOnly
-              value={publicUrl}
-              className="flex-1 h-10 px-3 rounded-xl bg-background ring-1 ring-border text-sm text-muted-foreground focus:outline-none"
-            />
-            <button
-              onClick={copyLink}
-              className="h-10 px-3 rounded-xl bg-primary text-primary-foreground text-sm font-medium flex items-center gap-1.5 hover:opacity-90 transition-opacity"
-            >
-              {copiedLink ? <Check className="w-4 h-4" /> : <Copy className="w-4 h-4" />}
-              {copiedLink ? 'Copied' : 'Copy'}
-            </button>
-            <a
-              href={ROUTES.splitBillPublic(billId)}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="h-10 w-10 rounded-xl bg-muted hover:bg-muted/80 flex items-center justify-center ring-1 ring-border"
-            >
-              <ExternalLink className="w-4 h-4" />
-            </a>
-          </div>
-        </div>
+        <ShareLinkRow
+          url={publicUrl}
+          href={ROUTES.splitBillPublic(billId)}
+        />
 
         {/* Payment accounts */}
         <div className="space-y-2">
           <p className="text-sm font-medium text-muted-foreground">Payment accounts</p>
           {bill.accounts.map((acc) => (
-            <div key={acc.id} className="flex items-center justify-between rounded-xl bg-muted/50 ring-1 ring-border px-4 py-3">
-              <div>
-                <p className="text-sm font-semibold">{acc.bankName}</p>
-                <p className="text-xs text-muted-foreground font-mono">{acc.accountNumber}</p>
-              </div>
-              <button
-                onClick={() => copyAccount(acc.accountNumber, acc.id)}
-                className="flex items-center gap-1.5 text-xs font-medium text-primary hover:underline"
-              >
-                {copiedAccount === acc.id ? <Check className="w-3.5 h-3.5" /> : <Copy className="w-3.5 h-3.5" />}
-                {copiedAccount === acc.id ? 'Copied' : 'Copy'}
-              </button>
-            </div>
+            <PaymentAccountItem
+              key={acc.id}
+              id={acc.id}
+              bankName={acc.bankName}
+              accountNumber={acc.accountNumber}
+            />
           ))}
         </div>
 
@@ -181,82 +143,40 @@ export function SplitBillManageView({ billId }: { billId: string }) {
               )}
 
               {p.status === 'proof_uploaded' && (
-                <div className="flex gap-2">
-                  <Button
-                    size="sm"
-                    className="flex-1 rounded-xl bg-green-500/15 text-green-700 dark:text-green-400 hover:bg-green-500/25"
-                    disabled={isUpdating}
-                    onClick={() => approveParticipant(p.id)}
-                  >
-                    Approve
-                  </Button>
-                  <Button
-                    size="sm"
-                    className="flex-1 rounded-xl bg-red-500/15 text-red-700 dark:text-red-400 hover:bg-red-500/25"
-                    disabled={isUpdating}
-                    onClick={() => rejectParticipant(p.id)}
-                  >
-                    Reject
-                  </Button>
-                </div>
+                <ProofActionsRow
+                  isUpdating={isUpdating}
+                  onApprove={() => approveParticipant(p.id)}
+                  onReject={() => rejectParticipant(p.id)}
+                />
               )}
             </div>
           ))}
         </div>
       </div>
 
-      {/* Proof image modal */}
-      {proofModal && (
-        <div
-          className="fixed inset-0 bg-black/80 z-50 flex items-center justify-center p-4"
-          onClick={() => setProofModal(null)}
-        >
-          <img src={proofModal} alt="Payment proof" className="max-w-full max-h-full rounded-xl object-contain" />
-        </div>
-      )}
+      <ProofImageModal
+        imageUrl={proofModal}
+        onClose={() => setProofModal(null)}
+      />
 
-      {/* Delete confirmation dialog */}
-      {showDeleteConfirm && (
-        <div
-          className="fixed inset-0 bg-black/60 z-50 flex items-end sm:items-center justify-center p-4"
-          onClick={() => setShowDeleteConfirm(false)}
-        >
-          <div
-            className="bg-background rounded-2xl p-6 w-full max-w-sm space-y-4 shadow-xl"
-            onClick={(e) => e.stopPropagation()}
-          >
-            <div className="space-y-1.5">
-              <h2 className="text-base font-semibold">Delete bill?</h2>
-              <p className="text-sm text-muted-foreground">
-                This will permanently delete <span className="font-medium text-foreground">{bill?.title}</span> and all
-                participant data. This cannot be undone.
-              </p>
-              {bill?.participants.some((p) => p.status === 'proof_uploaded' || p.status === 'approved') && (
-                <p className="text-sm text-yellow-700 dark:text-yellow-400 bg-yellow-500/10 rounded-xl px-3 py-2">
-                  Some participants have already submitted or been approved. Their proof data will be lost.
-                </p>
-              )}
-            </div>
-            <div className="flex gap-2">
-              <Button
-                variant="outline"
-                className="flex-1 rounded-xl"
-                onClick={() => setShowDeleteConfirm(false)}
-                disabled={isDeleting}
-              >
-                Cancel
-              </Button>
-              <Button
-                className="flex-1 rounded-xl bg-red-600 hover:bg-red-700 text-white"
-                disabled={isDeleting}
-                onClick={() => deleteBillById(() => router.push(ROUTES.splitBills))}
-              >
-                {isDeleting ? 'Deleting…' : 'Delete'}
-              </Button>
-            </div>
-          </div>
-        </div>
-      )}
+      <DeleteConfirmDialog
+        open={showDeleteConfirm}
+        onClose={() => setShowDeleteConfirm(false)}
+        title="Delete bill?"
+        description={
+          <>
+            This will permanently delete <span className="font-medium text-foreground">{bill?.title}</span> and all
+            participant data. This cannot be undone.
+          </>
+        }
+        warning={
+          bill?.participants.some((p) => p.status === 'proof_uploaded' || p.status === 'approved')
+            ? 'Some participants have already submitted or been approved. Their proof data will be lost.'
+            : undefined
+        }
+        isDeleting={isDeleting}
+        onConfirm={() => deleteBillById(() => router.push(ROUTES.splitBills))}
+      />
     </main>
   );
 }

--- a/src/features/split-bill/presentation/SplitBillManageView.tsx
+++ b/src/features/split-bill/presentation/SplitBillManageView.tsx
@@ -1,31 +1,15 @@
 'use client';
 
 import { useRouter } from 'next/navigation';
-import { ArrowLeft, ImageIcon, Pencil, Trash2 } from 'lucide-react';
+import { ArrowLeft, Pencil, Trash2 } from 'lucide-react';
 import { useState } from 'react';
 import { useSplitBillManageViewModel } from './useSplitBillManageViewModel';
-import { formatCurrency } from '@/shared/presentation/utils/formatCurrency';
 import { ROUTES } from '@/shared/presentation/navigation/routes';
-import type { ParticipantStatus } from '../domain/entities/SplitBillParticipant';
 import { ShareLinkRow } from '@/shared/presentation/common/organisms/ShareLinkRow';
-import { PaymentAccountItem } from '@/shared/presentation/common/organisms/PaymentAccountItem';
+import { PaymentAccountList } from '@/shared/presentation/common/organisms/PaymentAccountList';
 import { ProofImageModal } from '@/shared/presentation/common/organisms/ProofImageModal';
 import { DeleteConfirmDialog } from '@/shared/presentation/common/organisms/DeleteConfirmDialog';
-import { ProofActionsRow } from '@/shared/presentation/common/organisms/ProofActionsRow';
-
-const STATUS_STYLES: Record<ParticipantStatus, string> = {
-  pending: 'bg-muted text-muted-foreground',
-  proof_uploaded: 'bg-yellow-500/10 text-yellow-700 dark:text-yellow-400',
-  approved: 'bg-green-500/10 text-green-700 dark:text-green-400',
-  rejected: 'bg-red-500/10 text-red-700 dark:text-red-400',
-};
-
-const STATUS_LABEL: Record<ParticipantStatus, string> = {
-  pending: 'Pending',
-  proof_uploaded: 'Proof uploaded',
-  approved: 'Approved',
-  rejected: 'Rejected',
-};
+import { ManageParticipantCard } from '@/shared/presentation/common/organisms/ManageParticipantCard';
 
 export function SplitBillManageView({ billId }: { billId: string }) {
   const router = useRouter();
@@ -101,55 +85,25 @@ export function SplitBillManageView({ billId }: { billId: string }) {
         />
 
         {/* Payment accounts */}
-        <div className="space-y-2">
-          <p className="text-sm font-medium text-muted-foreground">Payment accounts</p>
-          {bill.accounts.map((acc) => (
-            <PaymentAccountItem
-              key={acc.id}
-              id={acc.id}
-              bankName={acc.bankName}
-              accountNumber={acc.accountNumber}
-            />
-          ))}
-        </div>
+        <PaymentAccountList accounts={bill.accounts} />
 
         {/* Participants */}
         <div className="space-y-2">
           <p className="text-sm font-medium text-muted-foreground">Participants</p>
           {bill.participants.map((p) => (
-            <div key={p.id} className="rounded-xl ring-1 ring-border p-4 space-y-3">
-              <div className="flex items-start justify-between gap-3">
-                <div>
-                  <p className="font-semibold flex items-center gap-2">
-                    {p.name}
-                    {p.isCreator && (
-                      <span className="text-xs bg-primary/10 text-primary px-1.5 py-0.5 rounded-md font-medium">Me</span>
-                    )}
-                  </p>
-                  <p className="text-sm font-medium text-primary">{formatCurrency(p.finalAmount, 'IDR')}</p>
-                </div>
-                <span className={`text-xs font-medium px-2.5 py-1 rounded-full ${STATUS_STYLES[p.status]}`}>
-                  {STATUS_LABEL[p.status]}
-                </span>
-              </div>
-
-              {p.proofImageUrl && (
-                <button
-                  onClick={() => setProofModal(p.proofImageUrl!)}
-                  className="flex items-center gap-2 text-sm text-primary hover:underline"
-                >
-                  <ImageIcon className="w-4 h-4" /> View proof
-                </button>
-              )}
-
-              {p.status === 'proof_uploaded' && (
-                <ProofActionsRow
-                  isUpdating={isUpdating}
-                  onApprove={() => approveParticipant(p.id)}
-                  onReject={() => rejectParticipant(p.id)}
-                />
-              )}
-            </div>
+            <ManageParticipantCard
+              key={p.id}
+              name={p.name}
+              amount={p.finalAmount}
+              status={p.status}
+              isCreator={p.isCreator}
+              creatorBadgeLabel="Bill creator"
+              proofImageUrl={p.proofImageUrl}
+              isUpdating={isUpdating}
+              onViewProof={p.proofImageUrl ? () => setProofModal(p.proofImageUrl!) : undefined}
+              onApprove={() => approveParticipant(p.id)}
+              onReject={() => rejectParticipant(p.id)}
+            />
           ))}
         </div>
       </div>

--- a/src/features/trips/presentation/views/TripDetailView.tsx
+++ b/src/features/trips/presentation/views/TripDetailView.tsx
@@ -2,13 +2,17 @@
 
 import { useState, useEffect } from 'react';
 import { useRouter } from 'next/navigation';
-import { ArrowLeft, Copy, Check, ExternalLink, ImageIcon, Plus, Trash2 } from 'lucide-react';
+import { ArrowLeft, ImageIcon, Plus, Trash2 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { useTripDetailViewModel } from '../state/useTripDetailViewModel';
 import { getStandaloneBillsAction } from '../actions/trips';
 import { formatCurrency } from '@/shared/presentation/utils/formatCurrency';
 import { ROUTES } from '@/shared/presentation/navigation/routes';
 import type { SettlementStatus } from '../../domain/entities/TripParticipantSettlement';
+import { ShareLinkRow } from '@/shared/presentation/common/organisms/ShareLinkRow';
+import { ProofImageModal } from '@/shared/presentation/common/organisms/ProofImageModal';
+import { DeleteConfirmDialog } from '@/shared/presentation/common/organisms/DeleteConfirmDialog';
+import { ProofActionsRow } from '@/shared/presentation/common/organisms/ProofActionsRow';
 
 const STATUS_STYLES: Record<SettlementStatus, string> = {
   pending: 'bg-muted text-muted-foreground',
@@ -44,17 +48,10 @@ export function TripDetailView({ tripId }: { tripId: string }) {
   const [selectedBillIds, setSelectedBillIds] = useState<string[]>([]);
   const [isFetchingBills, setIsFetchingBills] = useState(false);
   const [proofModal, setProofModal] = useState<string | null>(null);
-  const [copiedLink, setCopiedLink] = useState(false);
 
   const publicUrl = typeof window !== 'undefined'
     ? `${window.location.origin}${ROUTES.tripPublic(tripId)}`
     : ROUTES.tripPublic(tripId);
-
-  const copyPublicLink = () => {
-    navigator.clipboard.writeText(publicUrl);
-    setCopiedLink(true);
-    setTimeout(() => setCopiedLink(false), 2000);
-  };
 
   const totalAmount = tripDetail
     ? tripDetail.bills.reduce(
@@ -93,11 +90,11 @@ export function TripDetailView({ tripId }: { tripId: string }) {
 
   if (isLoading) {
     return (
-      <main className="min-h-screen px-4 pt-4 max-w-lg mx-auto">
+      <main className="px-4 pt-4 pb-8 max-w-lg mx-auto">
         <div className="h-8 w-48 bg-muted rounded-xl animate-pulse mb-4" />
         <div className="space-y-3">
           {[1, 2, 3].map((i) => (
-            <div key={i} className="h-24 rounded-2xl bg-muted animate-pulse" />
+            <div key={i} className="h-24 w-full rounded-2xl bg-muted animate-pulse" />
           ))}
         </div>
       </main>
@@ -161,31 +158,10 @@ export function TripDetailView({ tripId }: { tripId: string }) {
         </div>
 
         {/* Public share link */}
-        <div className="rounded-2xl bg-muted/50 ring-1 ring-border p-4 space-y-2">
-          <p className="text-sm font-medium">Share with participants</p>
-          <div className="flex gap-2">
-            <input
-              readOnly
-              value={publicUrl}
-              className="flex-1 h-10 px-3 rounded-xl bg-background ring-1 ring-border text-sm text-muted-foreground focus:outline-none"
-            />
-            <button
-              onClick={copyPublicLink}
-              className="h-10 px-3 rounded-xl bg-primary text-primary-foreground text-sm font-medium flex items-center gap-1.5 hover:opacity-90 transition-opacity"
-            >
-              {copiedLink ? <Check className="w-4 h-4" /> : <Copy className="w-4 h-4" />}
-              {copiedLink ? 'Copied' : 'Copy'}
-            </button>
-            <a
-              href={ROUTES.tripPublic(tripId)}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="h-10 w-10 rounded-xl bg-muted hover:bg-muted/80 flex items-center justify-center ring-1 ring-border"
-            >
-              <ExternalLink className="w-4 h-4" />
-            </a>
-          </div>
-        </div>
+        <ShareLinkRow
+          url={publicUrl}
+          href={ROUTES.tripPublic(tripId)}
+        />
 
         {/* Bills breakdown */}
         <div className="space-y-2">
@@ -264,39 +240,21 @@ export function TripDetailView({ tripId }: { tripId: string }) {
               )}
 
               {s.status === 'proof_uploaded' && (
-                <div className="flex gap-2">
-                  <Button
-                    size="sm"
-                    className="flex-1 rounded-xl bg-green-500/15 text-green-700 dark:text-green-400 hover:bg-green-500/25"
-                    disabled={isUpdatingStatus}
-                    onClick={() => updateSettlementStatus(s.id, 'approved')}
-                  >
-                    Approve
-                  </Button>
-                  <Button
-                    size="sm"
-                    className="flex-1 rounded-xl bg-red-500/15 text-red-700 dark:text-red-400 hover:bg-red-500/25"
-                    disabled={isUpdatingStatus}
-                    onClick={() => updateSettlementStatus(s.id, 'rejected')}
-                  >
-                    Reject
-                  </Button>
-                </div>
+                <ProofActionsRow
+                  isUpdating={isUpdatingStatus}
+                  onApprove={() => updateSettlementStatus(s.id, 'approved')}
+                  onReject={() => updateSettlementStatus(s.id, 'rejected')}
+                />
               )}
             </div>
           ))}
         </div>
       </div>
 
-      {/* Proof image modal */}
-      {proofModal && (
-        <div
-          className="fixed inset-0 bg-black/80 z-50 flex items-center justify-center p-4"
-          onClick={() => setProofModal(null)}
-        >
-          <img src={proofModal} alt="Settlement proof" className="max-w-full max-h-full rounded-xl object-contain" />
-        </div>
-      )}
+      <ProofImageModal
+        imageUrl={proofModal}
+        onClose={() => setProofModal(null)}
+      />
 
       {/* Add Bills dialog */}
       {showAddBills && (
@@ -361,44 +319,20 @@ export function TripDetailView({ tripId }: { tripId: string }) {
         </div>
       )}
 
-      {/* Delete confirmation */}
-      {showDeleteConfirm && (
-        <div
-          className="fixed inset-0 bg-black/60 z-50 flex items-end sm:items-center justify-center p-4"
-          onClick={() => setShowDeleteConfirm(false)}
-        >
-          <div
-            className="bg-background rounded-2xl p-6 w-full max-w-sm space-y-4 shadow-xl"
-            onClick={(e) => e.stopPropagation()}
-          >
-            <div className="space-y-1.5">
-              <h2 className="text-base font-semibold">Delete trip?</h2>
-              <p className="text-sm text-muted-foreground">
-                This will permanently delete{' '}
-                <span className="font-medium text-foreground">{trip.name}</span> and all
-                settlement data. Bills will become standalone again. This cannot be undone.
-              </p>
-            </div>
-            <div className="flex gap-2">
-              <Button
-                variant="outline"
-                className="flex-1 rounded-xl"
-                onClick={() => setShowDeleteConfirm(false)}
-                disabled={isDeleting}
-              >
-                Cancel
-              </Button>
-              <Button
-                className="flex-1 rounded-xl bg-red-600 hover:bg-red-700 text-white"
-                disabled={isDeleting}
-                onClick={() => deleteTrip(() => router.push(ROUTES.splitBills))}
-              >
-                {isDeleting ? 'Deleting…' : 'Delete'}
-              </Button>
-            </div>
-          </div>
-        </div>
-      )}
+      <DeleteConfirmDialog
+        open={showDeleteConfirm}
+        onClose={() => setShowDeleteConfirm(false)}
+        title="Delete trip?"
+        description={
+          <>
+            This will permanently delete{' '}
+            <span className="font-medium text-foreground">{trip.name}</span> and all
+            settlement data. Bills will become standalone again. This cannot be undone.
+          </>
+        }
+        isDeleting={isDeleting}
+        onConfirm={() => deleteTrip(() => router.push(ROUTES.splitBills))}
+      />
     </main>
   );
 }

--- a/src/features/trips/presentation/views/TripDetailView.tsx
+++ b/src/features/trips/presentation/views/TripDetailView.tsx
@@ -2,31 +2,17 @@
 
 import { useState, useEffect } from 'react';
 import { useRouter } from 'next/navigation';
-import { ArrowLeft, ImageIcon, Plus, Trash2 } from 'lucide-react';
+import { ArrowLeft, Plus, Trash2 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { useTripDetailViewModel } from '../state/useTripDetailViewModel';
 import { getStandaloneBillsAction } from '../actions/trips';
 import { formatCurrency } from '@/shared/presentation/utils/formatCurrency';
 import { ROUTES } from '@/shared/presentation/navigation/routes';
-import type { SettlementStatus } from '../../domain/entities/TripParticipantSettlement';
 import { ShareLinkRow } from '@/shared/presentation/common/organisms/ShareLinkRow';
 import { ProofImageModal } from '@/shared/presentation/common/organisms/ProofImageModal';
 import { DeleteConfirmDialog } from '@/shared/presentation/common/organisms/DeleteConfirmDialog';
-import { ProofActionsRow } from '@/shared/presentation/common/organisms/ProofActionsRow';
-
-const STATUS_STYLES: Record<SettlementStatus, string> = {
-  pending: 'bg-muted text-muted-foreground',
-  proof_uploaded: 'bg-yellow-500/10 text-yellow-700 dark:text-yellow-400',
-  approved: 'bg-green-500/10 text-green-700 dark:text-green-400',
-  rejected: 'bg-red-500/10 text-red-700 dark:text-red-400',
-};
-
-const STATUS_LABEL: Record<SettlementStatus, string> = {
-  pending: 'Pending',
-  proof_uploaded: 'Proof uploaded',
-  approved: 'Approved',
-  rejected: 'Rejected',
-};
+import { PaymentAccountList } from '@/shared/presentation/common/organisms/PaymentAccountList';
+import { ManageParticipantCard } from '@/shared/presentation/common/organisms/ManageParticipantCard';
 
 export function TripDetailView({ tripId }: { tripId: string }) {
   const router = useRouter();
@@ -115,6 +101,15 @@ export function TripDetailView({ tripId }: { tripId: string }) {
   const endDateLabel = trip.endDate ? trip.endDate.toISOString().split('T')[0] : null;
   const dateLabel = endDateLabel ? `${startDateLabel} → ${endDateLabel}` : startDateLabel;
 
+  // Deduplicate payment accounts across all bills by bankName-accountNumber
+  const seen = new Set<string>();
+  const uniqueAccounts = bills.flatMap((bill) => bill.accounts).filter((acc) => {
+    const key = `${acc.bankName}-${acc.accountNumber}`;
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
+
   return (
     <main className="min-h-screen">
       <div className="px-4 pt-4 pb-8 md:px-6 md:pt-6 max-w-lg mx-auto space-y-6">
@@ -162,6 +157,11 @@ export function TripDetailView({ tripId }: { tripId: string }) {
           url={publicUrl}
           href={ROUTES.tripPublic(tripId)}
         />
+
+        {/* Payment accounts */}
+        {uniqueAccounts.length > 0 && (
+          <PaymentAccountList accounts={uniqueAccounts} />
+        )}
 
         {/* Bills breakdown */}
         <div className="space-y-2">
@@ -214,39 +214,19 @@ export function TripDetailView({ tripId }: { tripId: string }) {
           )}
 
           {settlements.map((s) => (
-            <div key={s.id} className="rounded-xl ring-1 ring-border p-4 space-y-3">
-              <div className="flex items-start justify-between gap-3">
-                <div>
-                  <p className="font-semibold capitalize">{s.participantName}</p>
-                  {s.participantEmail && (
-                    <p className="text-xs text-muted-foreground">{s.participantEmail}</p>
-                  )}
-                  <p className="text-sm font-medium text-primary">
-                    {formatCurrency(s.totalNetAmount, 'IDR')}
-                  </p>
-                </div>
-                <span className={`text-xs font-medium px-2.5 py-1 rounded-full ${STATUS_STYLES[s.status]}`}>
-                  {STATUS_LABEL[s.status]}
-                </span>
-              </div>
-
-              {s.proofImageUrl && (
-                <button
-                  onClick={() => setProofModal(s.proofImageUrl!)}
-                  className="flex items-center gap-2 text-sm text-primary hover:underline"
-                >
-                  <ImageIcon className="w-4 h-4" /> View proof
-                </button>
-              )}
-
-              {s.status === 'proof_uploaded' && (
-                <ProofActionsRow
-                  isUpdating={isUpdatingStatus}
-                  onApprove={() => updateSettlementStatus(s.id, 'approved')}
-                  onReject={() => updateSettlementStatus(s.id, 'rejected')}
-                />
-              )}
-            </div>
+            <ManageParticipantCard
+              key={s.id}
+              name={s.participantName}
+              amount={s.totalNetAmount}
+              status={s.status}
+              isCreator={s.participantName.toLowerCase() === 'you'}
+              creatorBadgeLabel="Trip creator"
+              proofImageUrl={s.proofImageUrl}
+              isUpdating={isUpdatingStatus}
+              onViewProof={s.proofImageUrl ? () => setProofModal(s.proofImageUrl!) : undefined}
+              onApprove={() => updateSettlementStatus(s.id, 'approved')}
+              onReject={() => updateSettlementStatus(s.id, 'rejected')}
+            />
           ))}
         </div>
       </div>

--- a/src/features/trips/presentation/views/TripListView.tsx
+++ b/src/features/trips/presentation/views/TripListView.tsx
@@ -74,7 +74,7 @@ export function TripListView() {
         {isLoading && (
           <div className="space-y-2">
             {[1, 2].map((i) => (
-              <div key={i} className="h-16 rounded-2xl bg-muted animate-pulse" />
+              <div key={i} className="h-16 w-full rounded-2xl bg-muted animate-pulse" />
             ))}
           </div>
         )}

--- a/src/features/trips/presentation/views/TripPublicView.tsx
+++ b/src/features/trips/presentation/views/TripPublicView.tsx
@@ -236,7 +236,12 @@ export function TripPublicView({ tripId }: { tripId: string }) {
                 >
                   <div className="flex items-start justify-between gap-3">
                     <div>
-                      <p className="font-semibold">{displayName}</p>
+                      <p className="font-semibold flex items-center gap-2">
+                        {displayName}
+                        {isCreatorRow && (
+                          <span className="text-xs bg-primary/10 text-primary px-1.5 py-0.5 rounded-md font-medium">Trip creator</span>
+                        )}
+                      </p>
                       {s.participantEmail && (
                         <p className="text-xs text-muted-foreground">{s.participantEmail}</p>
                       )}
@@ -289,7 +294,7 @@ export function TripPublicView({ tripId }: { tripId: string }) {
       {/* Upload proof modal */}
       {selectedSettlement && (
         <div className="fixed inset-0 bg-black/60 z-50 flex items-end sm:items-center justify-center p-0 sm:p-4">
-          <div className="bg-background w-full sm:max-w-md rounded-t-2xl sm:rounded-2xl p-5 space-y-5">
+          <div className="bg-background w-full sm:max-w-md rounded-t-2xl sm:rounded-2xl p-5 space-y-5 max-h-[90vh] overflow-y-auto">
 
             {/* Loading state */}
             {isUploading && (

--- a/src/shared/presentation/common/organisms/DeleteConfirmDialog.tsx
+++ b/src/shared/presentation/common/organisms/DeleteConfirmDialog.tsx
@@ -1,0 +1,65 @@
+'use client';
+
+import React from 'react';
+import { Button } from '@/components/ui/button';
+
+interface DeleteConfirmDialogProps {
+  open: boolean;
+  onClose: () => void;
+  title: string;
+  description: React.ReactNode;
+  warning?: React.ReactNode;
+  isDeleting: boolean;
+  onConfirm: () => void;
+}
+
+export function DeleteConfirmDialog({
+  open,
+  onClose,
+  title,
+  description,
+  warning,
+  isDeleting,
+  onConfirm,
+}: DeleteConfirmDialogProps) {
+  if (!open) return null;
+
+  return (
+    <div
+      className="fixed inset-0 bg-black/60 z-50 flex items-end sm:items-center justify-center p-4"
+      onClick={onClose}
+    >
+      <div
+        className="bg-background rounded-2xl p-6 w-full max-w-sm space-y-4 shadow-xl"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="space-y-1.5">
+          <h2 className="text-base font-semibold">{title}</h2>
+          <p className="text-sm text-muted-foreground">{description}</p>
+          {warning && (
+            <div className="text-sm text-yellow-700 dark:text-yellow-400 bg-yellow-500/10 rounded-xl px-3 py-2">
+              {warning}
+            </div>
+          )}
+        </div>
+        <div className="flex gap-2">
+          <Button
+            variant="outline"
+            className="flex-1 rounded-xl"
+            onClick={onClose}
+            disabled={isDeleting}
+          >
+            Cancel
+          </Button>
+          <Button
+            className="flex-1 rounded-xl bg-red-600 hover:bg-red-700 text-white"
+            disabled={isDeleting}
+            onClick={onConfirm}
+          >
+            {isDeleting ? 'Deleting…' : 'Delete'}
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/shared/presentation/common/organisms/ManageParticipantCard.tsx
+++ b/src/shared/presentation/common/organisms/ManageParticipantCard.tsx
@@ -1,0 +1,87 @@
+'use client';
+
+import { ImageIcon } from 'lucide-react';
+import { formatCurrency } from '@/shared/presentation/utils/formatCurrency';
+import { ProofActionsRow } from './ProofActionsRow';
+
+type ParticipantStatus = 'pending' | 'proof_uploaded' | 'approved' | 'rejected';
+
+const STATUS_STYLES: Record<ParticipantStatus, string> = {
+  pending: 'bg-muted text-muted-foreground',
+  proof_uploaded: 'bg-yellow-500/10 text-yellow-700 dark:text-yellow-400',
+  approved: 'bg-green-500/10 text-green-700 dark:text-green-400',
+  rejected: 'bg-red-500/10 text-red-700 dark:text-red-400',
+};
+
+const STATUS_LABEL: Record<ParticipantStatus, string> = {
+  pending: 'Pending',
+  proof_uploaded: 'Proof uploaded',
+  approved: 'Approved',
+  rejected: 'Rejected',
+};
+
+interface ManageParticipantCardProps {
+  name: string;
+  amount: number;
+  status: ParticipantStatus;
+  isCreator?: boolean;
+  creatorBadgeLabel?: string;
+  proofImageUrl?: string | null;
+  isUpdating?: boolean;
+  onViewProof?: () => void;
+  onApprove?: () => void;
+  onReject?: () => void;
+}
+
+export function ManageParticipantCard({
+  name,
+  amount,
+  status,
+  isCreator = false,
+  creatorBadgeLabel = 'Creator',
+  proofImageUrl,
+  isUpdating = false,
+  onViewProof,
+  onApprove,
+  onReject,
+}: ManageParticipantCardProps) {
+  const displayStatus: ParticipantStatus = isCreator ? 'approved' : status;
+
+  return (
+    <div className="rounded-xl ring-1 ring-border p-4 space-y-3">
+      <div className="flex items-start justify-between gap-3">
+        <div>
+          <p className="font-semibold flex items-center gap-2">
+            {name}
+            {isCreator && (
+              <span className="text-xs bg-primary/10 text-primary px-1.5 py-0.5 rounded-md font-medium">
+                {creatorBadgeLabel}
+              </span>
+            )}
+          </p>
+          <p className="text-sm font-medium text-primary">{formatCurrency(amount, 'IDR')}</p>
+        </div>
+        <span className={`px-2.5 py-1 rounded-full text-xs font-medium ${STATUS_STYLES[displayStatus]}`}>
+          {STATUS_LABEL[displayStatus]}
+        </span>
+      </div>
+
+      {proofImageUrl && onViewProof && (
+        <button
+          onClick={onViewProof}
+          className="flex items-center gap-2 text-sm text-primary hover:underline"
+        >
+          <ImageIcon className="w-4 h-4" /> View proof
+        </button>
+      )}
+
+      {status === 'proof_uploaded' && onApprove && onReject && !isCreator && (
+        <ProofActionsRow
+          isUpdating={isUpdating}
+          onApprove={onApprove}
+          onReject={onReject}
+        />
+      )}
+    </div>
+  );
+}

--- a/src/shared/presentation/common/organisms/ManageParticipantCard.tsx
+++ b/src/shared/presentation/common/organisms/ManageParticipantCard.tsx
@@ -51,7 +51,7 @@ export function ManageParticipantCard({
     <div className="rounded-xl ring-1 ring-border p-4 space-y-3">
       <div className="flex items-start justify-between gap-3">
         <div>
-          <p className="font-semibold flex items-center gap-2">
+          <p className="font-semibold flex items-center gap-2 capitalize">
             {name}
             {isCreator && (
               <span className="text-xs bg-primary/10 text-primary px-1.5 py-0.5 rounded-md font-medium">

--- a/src/shared/presentation/common/organisms/PaymentAccountItem.tsx
+++ b/src/shared/presentation/common/organisms/PaymentAccountItem.tsx
@@ -19,7 +19,7 @@ export function PaymentAccountItem({ id, bankName, accountNumber }: PaymentAccou
   };
 
   return (
-    <div className="flex items-center justify-between rounded-xl bg-muted/50 ring-1 ring-border px-4 py-3">
+    <div className="flex items-center justify-between px-4 py-3">
       <div>
         <p className="text-sm font-semibold">{bankName}</p>
         <p className="text-xs text-muted-foreground font-mono">{accountNumber}</p>

--- a/src/shared/presentation/common/organisms/PaymentAccountItem.tsx
+++ b/src/shared/presentation/common/organisms/PaymentAccountItem.tsx
@@ -1,0 +1,36 @@
+'use client';
+
+import { useState } from 'react';
+import { Copy, Check } from 'lucide-react';
+
+interface PaymentAccountItemProps {
+  id: string;
+  bankName: string;
+  accountNumber: string;
+}
+
+export function PaymentAccountItem({ id, bankName, accountNumber }: PaymentAccountItemProps) {
+  const [copied, setCopied] = useState(false);
+
+  const copyAccount = () => {
+    navigator.clipboard.writeText(accountNumber);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  };
+
+  return (
+    <div className="flex items-center justify-between rounded-xl bg-muted/50 ring-1 ring-border px-4 py-3">
+      <div>
+        <p className="text-sm font-semibold">{bankName}</p>
+        <p className="text-xs text-muted-foreground font-mono">{accountNumber}</p>
+      </div>
+      <button
+        onClick={copyAccount}
+        className="flex items-center gap-1.5 text-xs font-medium text-primary hover:underline"
+      >
+        {copied ? <Check className="w-3.5 h-3.5" /> : <Copy className="w-3.5 h-3.5" />}
+        {copied ? 'Copied' : 'Copy'}
+      </button>
+    </div>
+  );
+}

--- a/src/shared/presentation/common/organisms/PaymentAccountList.tsx
+++ b/src/shared/presentation/common/organisms/PaymentAccountList.tsx
@@ -1,0 +1,30 @@
+import { PaymentAccountItem } from './PaymentAccountItem';
+
+interface PaymentAccount {
+  id: string;
+  bankName: string;
+  accountNumber: string;
+}
+
+interface PaymentAccountListProps {
+  label?: string;
+  accounts: PaymentAccount[];
+}
+
+export function PaymentAccountList({ label = 'Payment accounts', accounts }: PaymentAccountListProps) {
+  return (
+    <div>
+      <p className="text-sm font-medium text-muted-foreground mb-2">{label}</p>
+      <div className="rounded-2xl bg-muted/50 ring-1 ring-border divide-y divide-border overflow-hidden">
+        {accounts.map((acc) => (
+          <PaymentAccountItem
+            key={acc.id}
+            id={acc.id}
+            bankName={acc.bankName}
+            accountNumber={acc.accountNumber}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/shared/presentation/common/organisms/ProofActionsRow.tsx
+++ b/src/shared/presentation/common/organisms/ProofActionsRow.tsx
@@ -1,0 +1,32 @@
+'use client';
+
+import { Button } from '@/components/ui/button';
+
+interface ProofActionsRowProps {
+  isUpdating: boolean;
+  onApprove: () => void;
+  onReject: () => void;
+}
+
+export function ProofActionsRow({ isUpdating, onApprove, onReject }: ProofActionsRowProps) {
+  return (
+    <div className="flex gap-2">
+      <Button
+        size="sm"
+        className="flex-1 rounded-xl bg-green-500/15 text-green-700 dark:text-green-400 hover:bg-green-500/25"
+        disabled={isUpdating}
+        onClick={onApprove}
+      >
+        Approve
+      </Button>
+      <Button
+        size="sm"
+        className="flex-1 rounded-xl bg-red-500/15 text-red-700 dark:text-red-400 hover:bg-red-500/25"
+        disabled={isUpdating}
+        onClick={onReject}
+      >
+        Reject
+      </Button>
+    </div>
+  );
+}

--- a/src/shared/presentation/common/organisms/ProofImageModal.tsx
+++ b/src/shared/presentation/common/organisms/ProofImageModal.tsx
@@ -1,0 +1,23 @@
+'use client';
+
+interface ProofImageModalProps {
+  imageUrl: string | null;
+  onClose: () => void;
+}
+
+export function ProofImageModal({ imageUrl, onClose }: ProofImageModalProps) {
+  if (!imageUrl) return null;
+
+  return (
+    <div
+      className="fixed inset-0 bg-black/80 z-50 flex items-center justify-center p-4"
+      onClick={onClose}
+    >
+      <img
+        src={imageUrl}
+        alt="Payment proof"
+        className="max-w-full max-h-full rounded-xl object-contain"
+      />
+    </div>
+  );
+}

--- a/src/shared/presentation/common/organisms/ShareLinkRow.tsx
+++ b/src/shared/presentation/common/organisms/ShareLinkRow.tsx
@@ -1,0 +1,47 @@
+'use client';
+
+import { useState } from 'react';
+import { Copy, Check, ExternalLink } from 'lucide-react';
+
+interface ShareLinkRowProps {
+  url: string;
+  href: string;
+}
+
+export function ShareLinkRow({ url, href }: ShareLinkRowProps) {
+  const [copied, setCopied] = useState(false);
+
+  const copyLink = () => {
+    navigator.clipboard.writeText(url);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  };
+
+  return (
+    <div className="rounded-2xl bg-muted/50 ring-1 ring-border p-4 space-y-2">
+      <p className="text-sm font-medium">Share with participants</p>
+      <div className="flex gap-2">
+        <input
+          readOnly
+          value={url}
+          className="flex-1 h-10 px-3 rounded-xl bg-background ring-1 ring-border text-sm text-muted-foreground focus:outline-none"
+        />
+        <button
+          onClick={copyLink}
+          className="h-10 px-3 rounded-xl bg-primary text-primary-foreground text-sm font-medium flex items-center gap-1.5 hover:opacity-90 transition-opacity"
+        >
+          {copied ? <Check className="w-4 h-4" /> : <Copy className="w-4 h-4" />}
+          {copied ? 'Copied' : 'Copy'}
+        </button>
+        <a
+          href={href}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="h-10 w-10 shrink-0 rounded-xl bg-muted ring-1 ring-border flex items-center justify-center"
+        >
+          <ExternalLink className="w-4 h-4" />
+        </a>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
Closes #83

## Summary

- **Upload image fills screen on iOS** — added `max-h-[90vh] overflow-y-auto` to the trip settlement upload proof bottom sheet
- **Missing "Trip creator" badge** — added badge on the creator's settlement row in the public trip settlement page, matching the bill settlement page
- **"Go to page" icon shrinking** — added `shrink-0` to the ExternalLink anchor in both bill and trip detail views
- **Skeleton shows only 1 bar on mobile** — removed `min-h-screen` from early-return skeleton containers; added `w-full` to all skeleton items across trip/bill detail and list views

## Refactors (part of same branch)

- Extracted 5 shared organisms: `ShareLinkRow`, `PaymentAccountItem`, `PaymentAccountList`, `ProofImageModal`, `DeleteConfirmDialog`, `ProofActionsRow`, `ManageParticipantCard`
- Both `SplitBillManageView` and `TripDetailView` now use the shared components
- Trip detail now shows a grouped payment accounts section (deduped across all bills)
- "Me" badge renamed to "Bill creator" / "Trip creator" across manage views
- Trip creator settlement force-displayed as "Approved" (they pay upfront)
- Participant names capitalize-normalized in `ManageParticipantCard`

## Test plan

- [ ] Open trip settlement page on iOS — upload image stays within the modal, doesn't fill screen
- [ ] Trip settlement page — creator row shows "Trip creator" badge
- [ ] Bill/trip detail share section — external link button stays fixed size on narrow screens
- [ ] Trip detail skeleton shows 3 bars on mobile
- [ ] Bill detail skeleton shows 3 bars on mobile
- [ ] Split bill index standalone bills section shows 3 skeleton bars on mobile
- [ ] Bill detail: payment accounts in one grouped container, "Bill creator" badge visible
- [ ] Trip detail: payment accounts section present, "Trip creator" badge visible, creator row shows "Approved"

🤖 Generated with [Claude Code](https://claude.com/claude-code)