### PR TITLE
refactor: extract reusable components for public bill/trip pages

### DIFF
--- a/issues/000-backlog.md
+++ b/issues/000-backlog.md
@@ -2,6 +2,7 @@
 
 | # | Title | Status | Link |
 |---|-------|--------|------|
+| 085 | refactor: extract reusable components for public bill/trip pages | `pending` | [#85](https://github.com/handharr-labs/xpnsio/issues/85) |
 | 083 | fix(mobile): UI bugs in Split Bill and Trip features | `pending` | [#83](https://github.com/handharr-labs/xpnsio/issues/83) |
 | 081 | fix(trips): settlement UX improvements — merge payment accounts, save bank accounts to DB, replace 'You' with user name | `pending` | [#81](https://github.com/handharr-labs/xpnsio/issues/81) |
 | 077 | fix(trips): UX improvements for trip & split bill features | `pending` | [#77](https://github.com/handharr-labs/xpnsio/issues/77) |

--- a/src/features/split-bill/presentation/SplitBillPublicView.tsx
+++ b/src/features/split-bill/presentation/SplitBillPublicView.tsx
@@ -1,42 +1,24 @@
 'use client';
 
 import { useState, useRef } from 'react';
-import { Copy, Check, Upload, X, ImageIcon } from 'lucide-react';
+import { Upload, X, ImageIcon } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { useSplitBillPublicViewModel } from './useSplitBillPublicViewModel';
 import { formatCurrency } from '@/shared/presentation/utils/formatCurrency';
-import type { SplitBillParticipant, ParticipantStatus } from '../domain/entities/SplitBillParticipant';
-
-const STATUS_STYLES: Record<ParticipantStatus, string> = {
-  pending: '',
-  proof_uploaded: 'bg-yellow-500/10 ring-yellow-500/20 text-yellow-700 dark:text-yellow-400',
-  approved: 'bg-green-500/10 ring-green-500/20 text-green-700 dark:text-green-400',
-  rejected: 'bg-red-500/10 ring-red-500/20 text-red-700 dark:text-red-400',
-};
-
-const STATUS_LABEL: Record<ParticipantStatus, string> = {
-  pending: '',
-  proof_uploaded: 'Proof submitted — awaiting approval',
-  approved: 'Paid',
-  rejected: 'Proof rejected — contact the bill creator',
-};
+import { PaymentAccountList } from '@/shared/presentation/common/organisms/PaymentAccountList';
+import { PublicParticipantCard } from '@/shared/presentation/common/organisms/PublicParticipantCard';
+import type { SplitBillParticipant } from '../domain/entities/SplitBillParticipant';
 
 export function SplitBillPublicView({ billId }: { billId: string }) {
   const { bill, isLoading, isUploading, uploadError, uploadProof } =
     useSplitBillPublicViewModel(billId);
-  const [copiedAccount, setCopiedAccount] = useState<string | null>(null);
   const [selectedParticipant, setSelectedParticipant] = useState<SplitBillParticipant | null>(null);
   const [proofFile, setProofFile] = useState<File | null>(null);
   const [proofPreview, setProofPreview] = useState<string | null>(null);
   const [email, setEmail] = useState('');
   const [localError, setLocalError] = useState<string | null>(null);
+  const [copiedAccount, setCopiedAccount] = useState<string | null>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
-
-  const copyAccount = (text: string, id: string) => {
-    navigator.clipboard.writeText(text);
-    setCopiedAccount(id);
-    setTimeout(() => setCopiedAccount(null), 2000);
-  };
 
   const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
@@ -104,54 +86,28 @@ export function SplitBillPublicView({ billId }: { billId: string }) {
           </div>
 
           {/* Payment accounts */}
-          <div className="rounded-2xl bg-muted/50 ring-1 ring-border p-4 space-y-3">
-            <p className="text-sm font-semibold">Pay to</p>
-            {bill.accounts.map((acc) => (
-              <div key={acc.id} className="flex items-center justify-between">
-                <div>
-                  <p className="text-sm font-medium">{acc.bankName}</p>
-                  <p className="font-mono text-sm">{acc.accountNumber}</p>
-                </div>
-                <button
-                  onClick={() => copyAccount(acc.accountNumber, acc.id)}
-                  className="flex items-center gap-1.5 text-xs font-medium text-primary hover:underline min-h-[44px] px-2"
-                >
-                  {copiedAccount === acc.id ? <Check className="w-4 h-4" /> : <Copy className="w-4 h-4" />}
-                  {copiedAccount === acc.id ? 'Copied!' : 'Copy'}
-                </button>
-              </div>
-            ))}
-          </div>
+          <PaymentAccountList
+            label="Pay to"
+            accounts={bill.accounts.map((acc) => ({
+              id: acc.id,
+              bankName: acc.bankName,
+              accountNumber: acc.accountNumber,
+            }))}
+          />
 
           {/* Participants */}
           <div className="space-y-2">
             <p className="text-sm font-semibold">Who needs to pay</p>
             {bill.participants.map((p) => (
-              <div
+              <PublicParticipantCard
                 key={p.id}
-                className={`rounded-xl ring-1 p-4 ${p.status === 'pending' ? 'ring-border' : STATUS_STYLES[p.status]}`}
-              >
-                <div className="flex items-start justify-between gap-3">
-                  <div>
-                    <p className="font-semibold flex items-center gap-2">
-                      {p.isCreator ? 'You' : p.name}
-                      {p.isCreator && <span className="text-xs bg-primary/10 text-primary px-1.5 py-0.5 rounded-md font-medium">Bill creator</span>}
-                    </p>
-                    <p className="text-sm font-medium">{formatCurrency(p.finalAmount, 'IDR')}</p>
-                  </div>
-                  {p.status === 'pending' && !p.isCreator && (
-                    <button
-                      onClick={() => setSelectedParticipant(p)}
-                      className="text-sm font-medium px-3 py-1.5 rounded-lg border border-border hover:bg-accent transition-colors min-h-[44px] flex items-center"
-                    >
-                      I'm {p.name}
-                    </button>
-                  )}
-                  {(p.status !== 'pending' || p.isCreator) && (
-                    <span className="text-xs font-medium">{p.isCreator ? 'Paid' : STATUS_LABEL[p.status]}</span>
-                  )}
-                </div>
-              </div>
+                name={p.name}
+                amount={p.finalAmount}
+                isCreator={p.isCreator}
+                creatorBadgeLabel="Bill creator"
+                status={p.status}
+                onSelectSelf={!p.isCreator ? () => setSelectedParticipant(p) : undefined}
+              />
             ))}
           </div>
 
@@ -186,11 +142,14 @@ export function SplitBillPublicView({ billId }: { billId: string }) {
                 <div key={acc.id} className="flex items-center justify-between rounded-xl bg-muted/50 ring-1 ring-border px-3 py-2.5">
                   <span className="text-sm"><strong>{acc.bankName}</strong> · <span className="font-mono">{acc.accountNumber}</span></span>
                   <button
-                    onClick={() => copyAccount(acc.accountNumber, acc.id)}
+                    onClick={() => {
+                      navigator.clipboard.writeText(acc.accountNumber);
+                      setCopiedAccount(acc.id);
+                      setTimeout(() => setCopiedAccount(null), 2000);
+                    }}
                     className="text-xs font-medium text-primary hover:underline min-h-[44px] flex items-center gap-1 px-2"
                   >
-                    {copiedAccount === acc.id ? <Check className="w-3.5 h-3.5" /> : <Copy className="w-3.5 h-3.5" />}
-                    Copy
+                    {copiedAccount === acc.id ? 'Copied' : 'Copy'}
                   </button>
                 </div>
               ))}

--- a/src/features/trips/presentation/views/TripPublicView.tsx
+++ b/src/features/trips/presentation/views/TripPublicView.tsx
@@ -3,24 +3,14 @@
 import { useState, useRef } from 'react';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { useAction } from 'next-safe-action/hooks';
-import { Upload, X, ImageIcon, Check, Copy, Loader2, CheckCircle2 } from 'lucide-react';
+import { Upload, X, ImageIcon, Loader2, CheckCircle2 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { getTripDetailPublicAction, uploadTripSettlementProofAction } from '../actions/trips';
 import { formatCurrency } from '@/shared/presentation/utils/formatCurrency';
 import { createSupabaseBrowserClient } from '@/lib/supabase-browser';
-import type { TripParticipantSettlement, SettlementStatus } from '../../domain/entities/TripParticipantSettlement';
-
-const STATUS_STYLES: Partial<Record<SettlementStatus, string>> = {
-  proof_uploaded: 'bg-yellow-500/10 ring-yellow-500/20 text-yellow-700 dark:text-yellow-400',
-  approved: 'bg-green-500/10 ring-green-500/20 text-green-700 dark:text-green-400',
-  rejected: 'bg-red-500/10 ring-red-500/20 text-red-700 dark:text-red-400',
-};
-
-const STATUS_LABEL: Partial<Record<SettlementStatus, string>> = {
-  proof_uploaded: 'Proof submitted — awaiting approval',
-  approved: 'Paid',
-  rejected: 'Proof rejected — contact the trip creator',
-};
+import { PaymentAccountList } from '@/shared/presentation/common/organisms/PaymentAccountList';
+import { PublicParticipantCard } from '@/shared/presentation/common/organisms/PublicParticipantCard';
+import type { TripParticipantSettlement } from '../../domain/entities/TripParticipantSettlement';
 
 export function TripPublicView({ tripId }: { tripId: string }) {
   const { executeAsync: fetchTrip } = useAction(getTripDetailPublicAction);
@@ -35,14 +25,7 @@ export function TripPublicView({ tripId }: { tripId: string }) {
   const [uploadError, setUploadError] = useState<string | null>(null);
   const [localError, setLocalError] = useState<string | null>(null);
   const [uploadSuccess, setUploadSuccess] = useState(false);
-  const [copiedAccount, setCopiedAccount] = useState<string | null>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
-
-  const copyAccount = (accountNumber: string, id: string) => {
-    navigator.clipboard.writeText(accountNumber);
-    setCopiedAccount(id);
-    setTimeout(() => setCopiedAccount(null), 2000);
-  };
 
   const { data: tripDetail, isLoading } = useQuery({
     queryKey: ['trip-public', tripId],
@@ -177,24 +160,10 @@ export function TripPublicView({ tripId }: { tripId: string }) {
 
           {/* Payment accounts — shared across all bills */}
           {allPaymentAccounts.length > 0 && (
-            <div className='space-y-3'>
-              <p className='text-sm font-semibold'>Pay to {creatorName || 'the creator'}</p>
-              {allPaymentAccounts.map((acc) => (
-                <div key={acc.id} className='rounded-2xl bg-muted/50 ring-1 ring-border p-4 flex items-center justify-between'>
-                  <div>
-                    <p className='text-sm font-medium'>{acc.bankName}</p>
-                    <p className='font-mono text-sm'>{acc.accountNumber}</p>
-                  </div>
-                  <button
-                    onClick={() => copyAccount(acc.accountNumber, acc.id)}
-                    className='flex items-center gap-1.5 text-xs font-medium text-primary hover:underline min-h-[44px] px-2'
-                  >
-                    {copiedAccount === acc.id ? <Check className='w-4 h-4' /> : <Copy className='w-4 h-4' />}
-                    {copiedAccount === acc.id ? 'Copied!' : 'Copy'}
-                  </button>
-                </div>
-              ))}
-            </div>
+            <PaymentAccountList
+              label={`Pay to ${creatorName || 'the creator'}`}
+              accounts={allPaymentAccounts}
+            />
           )}
 
           {/* Bills summary */}
@@ -224,63 +193,42 @@ export function TripPublicView({ tripId }: { tripId: string }) {
             )}
 
             {settlements.map((s) => {
-              const statusStyle = STATUS_STYLES[s.status];
               const displayName = resolveDisplayName(s.participantName);
               const isCreatorRow = s.participantName.toLowerCase() === 'you'
-                || (creatorName && displayName.toLowerCase() === creatorName.toLowerCase());
+                || (creatorName !== '' && displayName.toLowerCase() === creatorName.toLowerCase());
+
+              // Per-bill breakdown rendered as children
+              const perBillBreakdown = bills.length > 0 ? (
+                <div className="mt-3 space-y-1">
+                  {bills.map((bill) => {
+                    const participant = bill.participants.find(
+                      (p) => p.name.toLowerCase() === s.participantName.toLowerCase()
+                        || p.name.toLowerCase() === displayName.toLowerCase()
+                    );
+                    if (!participant) return null;
+                    return (
+                      <div key={bill.id} className="flex items-center justify-between text-xs text-muted-foreground">
+                        <span className="truncate">{bill.title}</span>
+                        <span className="ml-2">{formatCurrency(participant.finalAmount, 'IDR')}</span>
+                      </div>
+                    );
+                  })}
+                </div>
+              ) : null;
 
               return (
-                <div
+                <PublicParticipantCard
                   key={s.id}
-                  className={`rounded-xl ring-1 p-4 ${s.status === 'pending' ? 'ring-border' : statusStyle}`}
+                  name={displayName}
+                  amount={s.totalNetAmount}
+                  isCreator={isCreatorRow}
+                  creatorBadgeLabel="Trip creator"
+                  status={s.status}
+                  email={s.participantEmail ?? undefined}
+                  onSelectSelf={!isCreatorRow ? () => setSelectedSettlement(s) : undefined}
                 >
-                  <div className="flex items-start justify-between gap-3">
-                    <div>
-                      <p className="font-semibold flex items-center gap-2">
-                        {displayName}
-                        {isCreatorRow && (
-                          <span className="text-xs bg-primary/10 text-primary px-1.5 py-0.5 rounded-md font-medium">Trip creator</span>
-                        )}
-                      </p>
-                      {s.participantEmail && (
-                        <p className="text-xs text-muted-foreground">{s.participantEmail}</p>
-                      )}
-                      <p className="text-sm font-medium">{formatCurrency(s.totalNetAmount, 'IDR')}</p>
-                    </div>
-                    {s.status === 'pending' && (
-                      <button
-                        onClick={() => setSelectedSettlement(s)}
-                        className="text-sm font-medium px-3 py-1.5 rounded-lg border border-border hover:bg-accent transition-colors min-h-[44px] flex items-center"
-                      >
-                        I'm {displayName}
-                      </button>
-                    )}
-                    {s.status !== 'pending' && (
-                      <span className="text-xs font-medium">
-                        {isCreatorRow && s.status === 'approved' ? 'Collecting' : STATUS_LABEL[s.status]}
-                      </span>
-                    )}
-                  </div>
-
-                  {/* Per-bill breakdown for selected participant */}
-                  {bills.length > 0 && (
-                    <div className="mt-3 space-y-1">
-                      {bills.map((bill) => {
-                        const participant = bill.participants.find(
-                          (p) => p.name.toLowerCase() === s.participantName.toLowerCase()
-                            || p.name.toLowerCase() === displayName.toLowerCase()
-                        );
-                        if (!participant) return null;
-                        return (
-                          <div key={bill.id} className="flex items-center justify-between text-xs text-muted-foreground">
-                            <span className="truncate">{bill.title}</span>
-                            <span className="ml-2">{formatCurrency(participant.finalAmount, 'IDR')}</span>
-                          </div>
-                        );
-                      })}
-                    </div>
-                  )}
-                </div>
+                  {perBillBreakdown}
+                </PublicParticipantCard>
               );
             })}
           </div>

--- a/src/shared/presentation/common/organisms/PublicParticipantCard.tsx
+++ b/src/shared/presentation/common/organisms/PublicParticipantCard.tsx
@@ -1,0 +1,124 @@
+'use client';
+
+import { formatCurrency } from '@/shared/presentation/utils/formatCurrency';
+
+type ParticipantStatus = 'pending' | 'proof_uploaded' | 'approved' | 'rejected';
+
+interface PublicParticipantCardProps {
+  name: string;
+  amount: number;
+  isCreator: boolean;
+  creatorBadgeLabel: string;
+  status: ParticipantStatus;
+  email?: string;
+  onSelectSelf?: () => void;
+  children?: React.ReactNode;
+}
+
+export function PublicParticipantCard({
+  name,
+  amount,
+  isCreator,
+  creatorBadgeLabel,
+  status,
+  email,
+  onSelectSelf,
+  children,
+}: PublicParticipantCardProps) {
+  if (isCreator) {
+    return (
+      <div className="rounded-xl ring-1 ring-green-500/20 bg-green-500/10 p-4 space-y-3">
+        <div className="flex items-start justify-between gap-3">
+          <div>
+            <p className="font-semibold flex items-center gap-2 text-green-500 dark:text-green-400">
+              {name}
+              <span className="text-xs bg-primary/10 text-primary px-1.5 py-0.5 rounded-md font-medium">
+                {creatorBadgeLabel}
+              </span>
+            </p>
+            {email && <p className="text-xs text-muted-foreground">{email}</p>}
+            <p className="text-sm font-medium text-green-500 dark:text-green-400">
+              {formatCurrency(amount, 'IDR')}
+            </p>
+          </div>
+          <span className="text-xs font-medium text-green-500 dark:text-green-400">Paid</span>
+        </div>
+        {children && <div>{children}</div>}
+      </div>
+    );
+  }
+
+  if (status === 'pending') {
+    return (
+      <div className="rounded-xl ring-1 ring-border p-4 space-y-3">
+        <div className="flex items-start justify-between gap-3">
+          <div>
+            <p className="font-semibold capitalize">{name}</p>
+            {email && <p className="text-xs text-muted-foreground">{email}</p>}
+            <p className="text-sm font-medium">{formatCurrency(amount, 'IDR')}</p>
+          </div>
+          {onSelectSelf && (
+            <button
+              onClick={onSelectSelf}
+              className="text-sm font-medium px-3 py-1.5 rounded-lg border border-border hover:bg-accent transition-colors min-h-[44px] flex items-center"
+            >
+              I'm {name}
+            </button>
+          )}
+        </div>
+        {children && <div>{children}</div>}
+      </div>
+    );
+  }
+
+  if (status === 'proof_uploaded') {
+    return (
+      <div className="rounded-xl ring-1 ring-yellow-500/20 bg-yellow-500/10 p-4 space-y-3">
+        <div className="flex items-start justify-between gap-3">
+          <div>
+            <p className="font-semibold capitalize">{name}</p>
+            {email && <p className="text-xs text-muted-foreground">{email}</p>}
+            <p className="text-sm font-medium">{formatCurrency(amount, 'IDR')}</p>
+          </div>
+          <span className="text-xs font-medium text-yellow-700 dark:text-yellow-400">
+            Proof submitted — awaiting approval
+          </span>
+        </div>
+        {children && <div>{children}</div>}
+      </div>
+    );
+  }
+
+  if (status === 'approved') {
+    return (
+      <div className="rounded-xl ring-1 ring-green-500/20 bg-green-500/10 p-4 space-y-3">
+        <div className="flex items-start justify-between gap-3">
+          <div>
+            <p className="font-semibold capitalize">{name}</p>
+            {email && <p className="text-xs text-muted-foreground">{email}</p>}
+            <p className="text-sm font-medium">{formatCurrency(amount, 'IDR')}</p>
+          </div>
+          <span className="text-xs font-medium text-green-700 dark:text-green-400">Paid</span>
+        </div>
+        {children && <div>{children}</div>}
+      </div>
+    );
+  }
+
+  // rejected
+  return (
+    <div className="rounded-xl ring-1 ring-red-500/20 bg-red-500/10 p-4 space-y-3">
+      <div className="flex items-start justify-between gap-3">
+        <div>
+          <p className="font-semibold capitalize">{name}</p>
+          {email && <p className="text-xs text-muted-foreground">{email}</p>}
+          <p className="text-sm font-medium">{formatCurrency(amount, 'IDR')}</p>
+        </div>
+        <span className="text-xs font-medium text-red-700 dark:text-red-400">
+          Proof rejected — contact the creator
+        </span>
+      </div>
+      {children && <div>{children}</div>}
+    </div>
+  );
+}


### PR DESCRIPTION
Closes #85

## Summary
- Adds `PublicParticipantCard` shared organism handling all 5 participant states (creator, pending, proof_uploaded, approved, rejected)
- Replaces inline payment accounts UI in both public views with existing `PaymentAccountList` + `PaymentAccountItem`
- Fixes bug where trip creator incorrectly received an "I'm [name]" button (`TripPublicView` had no `!isCreatorRow` guard)

## Commits
1. `feat(shared)` — new `PublicParticipantCard` organism
2. `refactor(split-bill)` — `SplitBillPublicView` uses shared components
3. `fix(trips)` — `TripPublicView` uses shared components + creator button bug fixed
4. `chore` — backlog + submodule

## Test plan
- [ ] Visit `/bill/[id]` — creator row shows green bg/text, "Paid" label, no "I'm" button
- [ ] Visit `/trip/[id]` — same for trip creator row
- [ ] Trip page: non-creator pending rows still show "I'm [name]" button
- [ ] Payment accounts sections render correctly on both pages (copy works)
- [ ] Per-bill breakdown still visible inside each settlement card on trip page

🤖 Generated with [Claude Code](https://claude.com/claude-code)