### PR TITLE
feat(split-bill): trip awareness improvements

### DIFF
--- a/issues/000-backlog.md
+++ b/issues/000-backlog.md
@@ -2,6 +2,7 @@
 
 | # | Title | Status | Link |
 |---|-------|--------|------|
+| 089 | feat: split bill — trip awareness improvements | `pending` | [#89](https://github.com/handharr-labs/xpnsio/issues/89) |
 | 087 | fix(split-bill): skeleton loading broken, share button overflow, creator badge styling, and proof submission RLS error | `pending` | [#87](https://github.com/handharr-labs/xpnsio/issues/87) |
 | 085 | refactor: extract reusable components for public bill/trip pages | `pending` | [#85](https://github.com/handharr-labs/xpnsio/issues/85) |
 | 083 | fix(mobile): UI bugs in Split Bill and Trip features | `pending` | [#83](https://github.com/handharr-labs/xpnsio/issues/83) |

--- a/src/features/split-bill/data/data-sources/SplitBillDbDataSource.ts
+++ b/src/features/split-bill/data/data-sources/SplitBillDbDataSource.ts
@@ -6,7 +6,11 @@ import type {
   SplitBillAdjustmentRow,
 } from '@/lib/schema';
 
-export interface SplitBillDetailRecord extends SplitBillRow {
+export interface SplitBillRowWithTrip extends SplitBillRow {
+  tripName: string | null;
+}
+
+export interface SplitBillDetailRecord extends SplitBillRowWithTrip {
   accounts: SplitBillAccountRow[];
   participants: (SplitBillParticipantRow & { assignedItemIds: string[] })[];
   items: (SplitBillItemRow & { assignedParticipantIds: string[] })[];
@@ -47,7 +51,7 @@ export interface UpdateBillDataParams {
 
 export interface SplitBillDbDataSource {
   findById(id: string): Promise<SplitBillDetailRecord | null>;
-  findByUserId(userId: string): Promise<SplitBillRow[]>;
+  findByUserId(userId: string): Promise<SplitBillRowWithTrip[]>;
   findStandaloneByUserId(userId: string): Promise<SplitBillRow[]>;
   createBill(params: CreateBillDataParams): Promise<SplitBillDetailRecord>;
   updateBill(params: UpdateBillDataParams): Promise<void>;

--- a/src/features/split-bill/data/data-sources/SplitBillDbDataSourceImpl.ts
+++ b/src/features/split-bill/data/data-sources/SplitBillDbDataSourceImpl.ts
@@ -7,21 +7,28 @@ import {
   splitBillItems,
   splitBillItemAssignments,
   splitBillAdjustments,
+  trips,
   type SplitBillRow,
   type SplitBillParticipantRow,
 } from '@/lib/schema';
 import type {
   SplitBillDbDataSource,
   SplitBillDetailRecord,
+  SplitBillRowWithTrip,
   CreateBillDataParams,
   UpdateBillDataParams,
 } from './SplitBillDbDataSource';
 
 export class SplitBillDbDataSourceImpl implements SplitBillDbDataSource {
   async findById(id: string): Promise<SplitBillDetailRecord | null> {
-    const bills = await db.select().from(splitBills).where(eq(splitBills.id, id)).limit(1);
-    if (!bills[0]) return null;
-    const bill = bills[0];
+    const rows = await db
+      .select({ bill: splitBills, tripName: trips.name })
+      .from(splitBills)
+      .leftJoin(trips, eq(splitBills.tripId, trips.id))
+      .where(eq(splitBills.id, id))
+      .limit(1);
+    if (!rows[0]) return null;
+    const bill = { ...rows[0].bill, tripName: rows[0].tripName ?? null };
 
     const [accounts, participants, items, adjustments] = await Promise.all([
       db.select().from(splitBillAccounts).where(eq(splitBillAccounts.billId, id)),
@@ -58,12 +65,14 @@ export class SplitBillDbDataSourceImpl implements SplitBillDbDataSource {
     return { ...bill, accounts, participants: participantsWithItems, items: itemsWithAssignees, adjustments };
   }
 
-  async findByUserId(userId: string): Promise<SplitBillRow[]> {
-    return db
-      .select()
+  async findByUserId(userId: string): Promise<SplitBillRowWithTrip[]> {
+    const rows = await db
+      .select({ bill: splitBills, tripName: trips.name })
       .from(splitBills)
+      .leftJoin(trips, eq(splitBills.tripId, trips.id))
       .where(eq(splitBills.userId, userId))
       .orderBy(desc(splitBills.createdAt));
+    return rows.map((r) => ({ ...r.bill, tripName: r.tripName ?? null }));
   }
 
   async findStandaloneByUserId(userId: string): Promise<SplitBillRow[]> {
@@ -163,7 +172,7 @@ export class SplitBillDbDataSourceImpl implements SplitBillDbDataSource {
         assignedItemIds: assignmentRows.filter((a) => a.participantId === p.id).map((a) => a.itemId),
       }));
 
-      return { ...bill, accounts, participants: participantsWithItems, items: itemsWithAssignees, adjustments: insertedAdjustments };
+      return { ...bill, tripName: null, accounts, participants: participantsWithItems, items: itemsWithAssignees, adjustments: insertedAdjustments };
     });
   }
 

--- a/src/features/split-bill/data/mappers/SplitBillMapper.ts
+++ b/src/features/split-bill/data/mappers/SplitBillMapper.ts
@@ -16,7 +16,7 @@ import type {
 } from '@/lib/schema';
 
 export class SplitBillMapper {
-  toBill(row: SplitBillRow): SplitBill {
+  toBill(row: SplitBillRow & { tripName?: string | null }): SplitBill {
     return {
       id: row.id,
       userId: row.userId,
@@ -24,6 +24,8 @@ export class SplitBillMapper {
       description: row.description ?? null,
       date: row.date,
       splitMode: row.splitMode,
+      tripId: row.tripId ?? null,
+      tripName: row.tripName ?? null,
       createdAt: row.createdAt,
     };
   }

--- a/src/features/split-bill/domain/entities/SplitBill.ts
+++ b/src/features/split-bill/domain/entities/SplitBill.ts
@@ -7,5 +7,7 @@ export interface SplitBill {
   readonly description: string | null;
   readonly date: string; // YYYY-MM-DD
   readonly splitMode: SplitMode;
+  readonly tripId: string | null;
+  readonly tripName: string | null;
   readonly createdAt: Date;
 }

--- a/src/features/split-bill/presentation/SplitBillListView.tsx
+++ b/src/features/split-bill/presentation/SplitBillListView.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useRouter } from 'next/navigation';
-import { Plus, Receipt } from 'lucide-react';
+import { Luggage, Plus, Receipt } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { useSplitBillListViewModel } from './useSplitBillListViewModel';
 import { TripListView } from '@/features/trips/presentation/views/TripListView';
@@ -80,6 +80,12 @@ export function SplitBillListView() {
                     <p className="text-xs text-muted-foreground mt-0.5">
                       {formatRelativeDate(bill.date)} · <span className="capitalize">{bill.splitMode}</span>
                     </p>
+                    {bill.tripName && (
+                      <span className="inline-flex items-center gap-1 mt-1.5 px-2 py-0.5 rounded-full text-xs font-medium bg-muted text-muted-foreground ring-1 ring-border">
+                        <Luggage className="w-3 h-3 flex-shrink-0" />
+                        {bill.tripName}
+                      </span>
+                    )}
                   </div>
                   <ArrowChevron />
                 </div>

--- a/src/features/split-bill/presentation/SplitBillManageView.tsx
+++ b/src/features/split-bill/presentation/SplitBillManageView.tsx
@@ -2,7 +2,7 @@
 
 import { useRouter } from 'next/navigation';
 import Link from 'next/link';
-import { ArrowLeft, Luggage, Pencil, Trash2 } from 'lucide-react';
+import { ArrowLeft, ArrowRight, Luggage, Pencil, Trash2 } from 'lucide-react';
 import { useState } from 'react';
 import { useSplitBillManageViewModel } from './useSplitBillManageViewModel';
 import { ROUTES } from '@/shared/presentation/navigation/routes';
@@ -90,9 +90,10 @@ export function SplitBillManageView({ billId }: { billId: string }) {
             <p className="text-sm flex-1">Part of <span className="font-medium">{bill.tripName}</span></p>
             <Link
               href={ROUTES.tripDetail(bill.tripId)}
-              className="text-sm font-medium text-primary hover:underline shrink-0"
+              className="inline-flex items-center gap-1 text-xs font-medium px-2.5 py-1 rounded-lg bg-background ring-1 ring-border hover:bg-muted transition-colors shrink-0"
             >
               Go to trip
+              <ArrowRight className="w-3 h-3" />
             </Link>
           </div>
         )}

--- a/src/features/split-bill/presentation/SplitBillManageView.tsx
+++ b/src/features/split-bill/presentation/SplitBillManageView.tsx
@@ -1,7 +1,8 @@
 'use client';
 
 import { useRouter } from 'next/navigation';
-import { ArrowLeft, Pencil, Trash2 } from 'lucide-react';
+import Link from 'next/link';
+import { ArrowLeft, Luggage, Pencil, Trash2 } from 'lucide-react';
 import { useState } from 'react';
 import { useSplitBillManageViewModel } from './useSplitBillManageViewModel';
 import { ROUTES } from '@/shared/presentation/navigation/routes';
@@ -19,8 +20,13 @@ export function SplitBillManageView({ billId }: { billId: string }) {
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
 
   const publicUrl = typeof window !== 'undefined'
-    ? `${window.location.origin}${ROUTES.splitBillPublic(billId)}`
+    ? bill?.tripId
+      ? `${window.location.origin}${ROUTES.tripPublic(bill.tripId)}`
+      : `${window.location.origin}${ROUTES.splitBillPublic(billId)}`
     : '';
+  const shareHref = bill?.tripId
+    ? ROUTES.tripPublic(bill.tripId)
+    : ROUTES.splitBillPublic(billId);
 
   if (isLoading) {
     return (
@@ -78,10 +84,23 @@ export function SplitBillManageView({ billId }: { billId: string }) {
           </div>
         )}
 
+        {bill.tripId && (
+          <div className="flex items-center gap-3 rounded-xl ring-1 ring-border bg-muted px-4 py-3">
+            <Luggage className="w-4 h-4 shrink-0 text-muted-foreground" />
+            <p className="text-sm flex-1">Part of <span className="font-medium">{bill.tripName}</span></p>
+            <Link
+              href={ROUTES.tripDetail(bill.tripId)}
+              className="text-sm font-medium text-primary hover:underline shrink-0"
+            >
+              Go to trip
+            </Link>
+          </div>
+        )}
+
         {/* Share link */}
         <ShareLinkRow
           url={publicUrl}
-          href={ROUTES.splitBillPublic(billId)}
+          href={shareHref}
         />
 
         {/* Payment accounts */}

--- a/src/features/split-bill/presentation/SplitBillPublicView.tsx
+++ b/src/features/split-bill/presentation/SplitBillPublicView.tsx
@@ -1,12 +1,14 @@
 'use client';
 
 import { useState, useRef } from 'react';
-import { Upload, X, ImageIcon } from 'lucide-react';
+import Link from 'next/link';
+import { Upload, X, ImageIcon, Luggage } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { useSplitBillPublicViewModel } from './useSplitBillPublicViewModel';
 import { formatCurrency } from '@/shared/presentation/utils/formatCurrency';
 import { PaymentAccountList } from '@/shared/presentation/common/organisms/PaymentAccountList';
 import { PublicParticipantCard } from '@/shared/presentation/common/organisms/PublicParticipantCard';
+import { ROUTES } from '@/shared/presentation/navigation/routes';
 import type { SplitBillParticipant } from '../domain/entities/SplitBillParticipant';
 
 export function SplitBillPublicView({ billId }: { billId: string }) {
@@ -70,6 +72,30 @@ export function SplitBillPublicView({ billId }: { billId: string }) {
     return (
       <main className="min-h-screen flex items-center justify-center px-4">
         <p className="text-muted-foreground text-center">Bill not found or has expired.</p>
+      </main>
+    );
+  }
+
+  if (bill.tripId) {
+    return (
+      <main className="min-h-screen flex items-center justify-center px-4">
+        <div className="max-w-sm w-full text-center space-y-4">
+          <div className="w-14 h-14 rounded-2xl bg-muted flex items-center justify-center mx-auto">
+            <Luggage className="w-7 h-7 text-muted-foreground" />
+          </div>
+          <div className="space-y-2">
+            <h1 className="text-xl font-bold tracking-tight">This bill is part of a trip</h1>
+            <p className="text-sm text-muted-foreground">
+              Paying here only settles this individual bill. To see and pay the full trip total, visit the trip page.
+            </p>
+          </div>
+          <Link
+            href={ROUTES.tripPublic(bill.tripId)}
+            className="inline-block w-full rounded-xl bg-primary text-primary-foreground px-4 py-2 text-center text-sm font-medium"
+          >
+            View trip page
+          </Link>
+        </div>
       </main>
     );
   }


### PR DESCRIPTION
Closes #89

## Summary

- **Trip badge on bill list** — bill cards show a pill badge with a luggage icon and trip name when the bill belongs to a trip
- **Block individual public page for trip bills** — visiting `/bill/[id]` for a trip-linked bill now replaces the payment UI with a redirect notice pointing to the trip's public page (prevents accidental partial payment)
- **Trip banner + swapped share link in manage view** — owners see an info banner with trip name and a "Go to trip" button; the share link is swapped to the trip's public URL so the right link gets shared

Old individual bill links shared before a bill was added to a trip still work — they redirect gracefully to the trip page.

## Test plan

- [ ] Create a standalone bill — verify no trip badge, share link points to `/bill/[id]`, public page shows payment UI normally
- [ ] Add the bill to a trip — verify trip name badge appears on bill list
- [ ] Open bill manage page — verify trip banner shows trip name, "Go to trip" navigates to trip detail, share link shows trip public URL
- [ ] Visit the old `/bill/[id]` public link — verify it shows the trip redirect screen with a link to the trip public page
- [ ] Visit the trip public page — verify payment flow works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)