### PR TITLE
fix(mobile): extend w-full skeleton fix to all remaining screens

### DIFF
--- a/issues/000-backlog.md
+++ b/issues/000-backlog.md
@@ -2,6 +2,7 @@
 
 | # | Title | Status | Link |
 |---|-------|--------|------|
+| 091 | fix(mobile): extend w-full skeleton fix to all remaining screens | `pending` | [#91](https://github.com/handharr-labs/xpnsio/issues/91) |
 | 089 | feat: split bill — trip awareness improvements | `pending` | [#89](https://github.com/handharr-labs/xpnsio/issues/89) |
 | 087 | fix(split-bill): skeleton loading broken, share button overflow, creator badge styling, and proof submission RLS error | `pending` | [#87](https://github.com/handharr-labs/xpnsio/issues/87) |
 | 085 | refactor: extract reusable components for public bill/trip pages | `pending` | [#85](https://github.com/handharr-labs/xpnsio/issues/85) |

--- a/src/features/budget-settings/presentation/BudgetSettingsView.tsx
+++ b/src/features/budget-settings/presentation/BudgetSettingsView.tsx
@@ -107,7 +107,7 @@ export function BudgetSettingsView() {
           {isLoading ? (
             <div className="space-y-4">
               {[1, 2].map((i) => (
-                <div key={i} className="h-48 rounded-2xl bg-muted animate-pulse" />
+                <div key={i} className="h-48 w-full rounded-2xl bg-muted animate-pulse" />
               ))}
             </div>
           ) : budgetSettings.length === 0 ? (

--- a/src/features/categories/presentation/CategoriesView.tsx
+++ b/src/features/categories/presentation/CategoriesView.tsx
@@ -145,7 +145,7 @@ export function CategoriesView() {
           {isLoading ? (
             <div className="space-y-4">
               {[1, 2, 3].map((i) => (
-                <div key={i} className="h-32 rounded-xl bg-muted animate-pulse" />
+                <div key={i} className="h-32 w-full rounded-xl bg-muted animate-pulse" />
               ))}
             </div>
           ) : categories.length === 0 ? (

--- a/src/features/dashboard/presentation/DashboardView.tsx
+++ b/src/features/dashboard/presentation/DashboardView.tsx
@@ -75,11 +75,11 @@ export function DashboardView() {
           {/* Loading State */}
           {isLoading ? (
             <div className="space-y-4">
-              <div className="h-48 rounded-2xl bg-zinc-800/50 animate-pulse" />
+              <div className="h-48 w-full rounded-2xl bg-zinc-800/50 animate-pulse" />
               <div className="h-8 w-32 rounded-lg bg-zinc-800/50 animate-pulse" />
               <div className="grid gap-3 md:grid-cols-2">
                 {[1, 2, 3, 4].map((i) => (
-                  <div key={i} className="h-32 rounded-xl bg-zinc-800/50 animate-pulse" />
+                  <div key={i} className="h-32 w-full rounded-xl bg-zinc-800/50 animate-pulse" />
                 ))}
               </div>
             </div>

--- a/src/features/split-bill/presentation/SplitBillFormView.tsx
+++ b/src/features/split-bill/presentation/SplitBillFormView.tsx
@@ -74,8 +74,8 @@ export function SplitBillFormView({ vm }: { vm: SplitBillFormVm }) {
     return (
       <main className="min-h-screen px-4 pt-4 max-w-lg mx-auto space-y-4">
         <div className="h-11 w-40 rounded-xl bg-muted animate-pulse" />
-        <div className="h-2 rounded-full bg-muted animate-pulse" />
-        {[1, 2, 3].map((i) => <div key={i} className="h-14 rounded-xl bg-muted animate-pulse" />)}
+        <div className="h-2 w-full rounded-full bg-muted animate-pulse" />
+        {[1, 2, 3].map((i) => <div key={i} className="h-14 w-full rounded-xl bg-muted animate-pulse" />)}
       </main>
     );
   }

--- a/src/features/split-bill/presentation/SplitBillPublicView.tsx
+++ b/src/features/split-bill/presentation/SplitBillPublicView.tsx
@@ -62,7 +62,7 @@ export function SplitBillPublicView({ billId }: { billId: string }) {
         <div className="h-7 w-48 bg-muted rounded-xl animate-pulse" />
         <div className="h-4 w-32 bg-muted rounded-xl animate-pulse" />
         <div className="space-y-3 mt-6">
-          {[1, 2, 3].map((i) => <div key={i} className="h-16 rounded-2xl bg-muted animate-pulse" />)}
+          {[1, 2, 3].map((i) => <div key={i} className="h-16 w-full rounded-2xl bg-muted animate-pulse" />)}
         </div>
       </main>
     );

--- a/src/features/transactions/presentation/TransactionDetailView.tsx
+++ b/src/features/transactions/presentation/TransactionDetailView.tsx
@@ -79,8 +79,8 @@ export function TransactionDetailView({ id }: { id: string }) {
         <div className="px-4 pt-4 pb-8 md:px-6 md:pt-6">
           <div className="max-w-lg mx-auto space-y-6">
             <div className="h-11 w-32 rounded-xl bg-muted animate-pulse" />
-            <div className="h-48 rounded-2xl bg-muted animate-pulse" />
-            <div className="h-32 rounded-xl bg-muted animate-pulse" />
+            <div className="h-48 w-full rounded-2xl bg-muted animate-pulse" />
+            <div className="h-32 w-full rounded-xl bg-muted animate-pulse" />
           </div>
         </div>
       </main>

--- a/src/features/transactions/presentation/TransactionsView.tsx
+++ b/src/features/transactions/presentation/TransactionsView.tsx
@@ -138,7 +138,7 @@ export function TransactionsView() {
           {isLoading ? (
             <div className="space-y-3">
               {[1, 2, 3, 4, 5].map((i) => (
-                <div key={i} className="h-16 rounded-xl bg-zinc-800/50 animate-pulse" />
+                <div key={i} className="h-16 w-full rounded-xl bg-zinc-800/50 animate-pulse" />
               ))}
             </div>
           ) : transactions.length === 0 ? (

--- a/src/features/trips/presentation/views/TripPublicView.tsx
+++ b/src/features/trips/presentation/views/TripPublicView.tsx
@@ -89,7 +89,7 @@ export function TripPublicView({ tripId }: { tripId: string }) {
         <div className="h-4 w-32 bg-muted rounded-xl animate-pulse" />
         <div className="space-y-3 mt-6">
           {[1, 2, 3].map((i) => (
-            <div key={i} className="h-16 rounded-2xl bg-muted animate-pulse" />
+            <div key={i} className="h-16 w-full rounded-2xl bg-muted animate-pulse" />
           ))}
         </div>
       </main>


### PR DESCRIPTION
Closes #91

## Summary
- The previous fix (120cfca) only patched `SplitBillListView` and `TripListView`, leaving 8 skeleton items across 7 screens still collapsing to zero width on iOS
- Added `w-full` to all remaining `animate-pulse` skeleton divs that lacked an explicit width
- Screens covered: Dashboard, Transactions, TransactionDetail, Categories, BudgetSettings, SplitBillPublic, SplitBillForm, TripPublic

## Test plan
- [ ] Open each fixed screen on an iOS device/simulator and confirm skeleton bars are visible during initial load
- [ ] Verify skeleton bars render correctly on desktop (no layout regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)