### PR TITLE
fix(split-bill): multiple UI bugs in new split bill flow

### DIFF
--- a/issues/000-backlog.md
+++ b/issues/000-backlog.md
@@ -2,6 +2,7 @@
 
 | # | Title | Status | Link |
 |---|-------|--------|------|
+| 093 | fix(split-bill): multiple UI bugs in new split bill flow | `pending` | [#93](https://github.com/handharr-labs/xpnsio/issues/93) |
 | 091 | fix(mobile): extend w-full skeleton fix to all remaining screens | `pending` | [#91](https://github.com/handharr-labs/xpnsio/issues/91) |
 | 089 | feat: split bill — trip awareness improvements | `pending` | [#89](https://github.com/handharr-labs/xpnsio/issues/89) |
 | 087 | fix(split-bill): skeleton loading broken, share button overflow, creator badge styling, and proof submission RLS error | `pending` | [#87](https://github.com/handharr-labs/xpnsio/issues/87) |

--- a/src/app/(main)/split-bill/new/page.tsx
+++ b/src/app/(main)/split-bill/new/page.tsx
@@ -1,5 +1,10 @@
+import { Suspense } from 'react';
 import { SplitBillNewView } from '@/features/split-bill/presentation/SplitBillNewView';
 
 export default function SplitBillNewPage() {
-  return <SplitBillNewView />;
+  return (
+    <Suspense fallback={null}>
+      <SplitBillNewView />
+    </Suspense>
+  );
 }

--- a/src/features/split-bill/presentation/SplitBillFormView.tsx
+++ b/src/features/split-bill/presentation/SplitBillFormView.tsx
@@ -185,7 +185,7 @@ export function SplitBillFormView({ vm }: { vm: SplitBillFormVm }) {
                       {p.isCreator ? (
                         <div className={`${inputCls} flex-1 flex items-center gap-2 cursor-default select-none`}>
                           <span className="font-medium">{p.name}</span>
-                          <span className="text-xs bg-primary/10 text-primary px-1.5 py-0.5 rounded-md font-medium">Me</span>
+                          <span className="text-xs bg-primary/10 text-primary px-2.5 py-1 rounded-full font-medium">Me</span>
                         </div>
                       ) : (
                         <input
@@ -409,7 +409,7 @@ export function SplitBillFormView({ vm }: { vm: SplitBillFormVm }) {
                       onValueChange={(v) => vm.updateAdjustment(adj.localId, { type: v as AdjustmentForm['type'] })}
                     >
                       <SelectTrigger className="w-44 flex-none !h-11 rounded-xl bg-muted/50 ring-1 ring-border px-4 text-sm">
-                        <SelectValue />
+                        <SelectValue>{adj.type === 'percentage' ? 'Percentage (%)' : 'Fixed (IDR)'}</SelectValue>
                       </SelectTrigger>
                       <SelectContent>
                         <SelectItem value="percentage">Percentage (%)</SelectItem>
@@ -493,7 +493,7 @@ export function SplitBillFormView({ vm }: { vm: SplitBillFormVm }) {
                 <div key={p.localId} className="flex items-center justify-between py-3 px-4 rounded-xl bg-muted/50 ring-1 ring-border">
                   <span className="font-medium flex items-center gap-2">
                     {p.name}
-                    {p.isCreator && <span className="text-xs bg-primary/10 text-primary px-1.5 py-0.5 rounded-md font-medium">Me</span>}
+                    {p.isCreator && <span className="text-xs bg-primary/10 text-primary px-2.5 py-1 rounded-full font-medium">Me</span>}
                   </span>
                   <span className="font-semibold">{formatCurrency(finalAmounts[p.localId] ?? 0, 'IDR')}</span>
                 </div>


### PR DESCRIPTION
Closes #93

## Summary
- **Step indicator missing in prod**: wrapped `<SplitBillNewView />` in `<Suspense>` to prevent SSR hydration failures from hiding the component
- **"Me" badge broken**: aligned badge style to `rounded-full px-2.5 py-1` in both Participants and Review steps, matching `ManageParticipantCard`
- **Adjustment dropdown broken**: `<SelectValue>` now renders explicit labels from state instead of relying on base-ui's lazy label resolution (which requires the popup to open first)

## Test plan
- [ ] Navigate to `/split-bill/new` on production Vercel — step indicator should be visible
- [ ] Reach step 2 (Participants) — "Me" badge should be pill-shaped, consistent with trip detail
- [ ] Reach last step (Review) — "Me" badge same as above
- [ ] Reach step 3 (Adjustments), add an adjustment — dropdown trigger should show "Percentage (%)" / "Fixed (IDR)" correctly on initial render and after selection

🤖 Generated with [Claude Code](https://claude.com/claude-code)