### PR TITLE
fix: skeleton loading missing in production on split-bill pages

### DIFF
--- a/.claude/agents/feature-planner.md
+++ b/.claude/agents/feature-planner.md
@@ -1,0 +1,1 @@
+../software-dev-agentic/lib/core/agents/builder/feature-planner.md

--- a/.claude/agents/prompt-debug-worker.md
+++ b/.claude/agents/prompt-debug-worker.md
@@ -1,0 +1,1 @@
+../software-dev-agentic/lib/core/agents/detective/prompt-debug-worker.md

--- a/.claude/reference/layer-contracts.md
+++ b/.claude/reference/layer-contracts.md
@@ -1,0 +1,1 @@
+../software-dev-agentic/lib/core/reference/clean-arch/layer-contracts.md

--- a/.claude/skills/plan
+++ b/.claude/skills/plan
@@ -1,0 +1,1 @@
+../software-dev-agentic/lib/core/skills/plan

--- a/issues/000-backlog.md
+++ b/issues/000-backlog.md
@@ -2,6 +2,7 @@
 
 | # | Title | Status | Link |
 |---|-------|--------|------|
+| 095 | fix: skeleton loading missing for standalone bills section on split-bill page in production | `pending` | [#95](https://github.com/handharr-labs/xpnsio/issues/95) |
 | 093 | fix(split-bill): multiple UI bugs in new split bill flow | `pending` | [#93](https://github.com/handharr-labs/xpnsio/issues/93) |
 | 091 | fix(mobile): extend w-full skeleton fix to all remaining screens | `pending` | [#91](https://github.com/handharr-labs/xpnsio/issues/91) |
 | 089 | feat: split bill — trip awareness improvements | `pending` | [#89](https://github.com/handharr-labs/xpnsio/issues/89) |

--- a/src/app/(main)/split-bill/[id]/loading.tsx
+++ b/src/app/(main)/split-bill/[id]/loading.tsx
@@ -1,0 +1,14 @@
+export default function SplitBillManageLoading() {
+  return (
+    <main className="min-h-screen">
+      <div className="px-4 pt-4 pb-8 md:px-6 md:pt-6 max-w-lg mx-auto">
+        <div className="h-8 w-48 bg-muted rounded-xl animate-pulse mb-4" />
+        <div className="space-y-3">
+          {[1, 2, 3].map((i) => (
+            <div key={i} className="h-24 w-full rounded-2xl bg-muted animate-pulse" />
+          ))}
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/src/app/(main)/split-bill/loading.tsx
+++ b/src/app/(main)/split-bill/loading.tsx
@@ -1,0 +1,48 @@
+import { MapPin, Receipt } from 'lucide-react';
+
+export default function SplitBillLoading() {
+  return (
+    <main className="min-h-screen">
+      <div className="px-4 pt-4 pb-8 md:px-6 md:pt-6 max-w-lg mx-auto">
+        <header className="flex items-center justify-between mb-8">
+          <div className="h-8 w-32 rounded-lg bg-muted animate-pulse" />
+          <div className="h-8 w-24 rounded-xl bg-muted animate-pulse" />
+        </header>
+
+        {/* Trips section skeleton */}
+        <div className="mb-6 space-y-2">
+          <div className="flex items-start justify-between gap-3">
+            <div>
+              <p className="text-sm font-semibold text-muted-foreground flex items-center gap-1.5">
+                <MapPin className="w-3.5 h-3.5" /> Trips
+              </p>
+              <p className="text-xs text-muted-foreground mt-0.5">
+                Group multiple bills from one trip. Participants pay one net settlement.
+              </p>
+            </div>
+          </div>
+          <div className="space-y-2">
+            {[1, 2].map((i) => (
+              <div key={i} className="h-16 w-full rounded-2xl bg-muted animate-pulse" />
+            ))}
+          </div>
+        </div>
+
+        {/* Standalone bills section skeleton */}
+        <div className="mb-2">
+          <p className="text-sm font-semibold text-muted-foreground flex items-center gap-1.5">
+            <Receipt className="w-3.5 h-3.5" /> Standalone Bills
+          </p>
+          <p className="text-xs text-muted-foreground mt-0.5">
+            One-off bills split directly with participants. Each bill is settled individually.
+          </p>
+        </div>
+        <div className="space-y-3">
+          {[1, 2, 3].map((i) => (
+            <div key={i} className="h-20 w-full rounded-2xl bg-muted animate-pulse" />
+          ))}
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/src/app/(main)/split-bill/trips/[tripId]/loading.tsx
+++ b/src/app/(main)/split-bill/trips/[tripId]/loading.tsx
@@ -1,0 +1,14 @@
+export default function TripDetailLoading() {
+  return (
+    <main className="min-h-screen">
+      <div className="px-4 pt-4 pb-8 md:px-6 md:pt-6 max-w-lg mx-auto">
+        <div className="h-8 w-48 bg-muted rounded-xl animate-pulse mb-4" />
+        <div className="space-y-3">
+          {[1, 2, 3].map((i) => (
+            <div key={i} className="h-24 w-full rounded-2xl bg-muted animate-pulse" />
+          ))}
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/src/features/split-bill/presentation/useSplitBillListViewModel.ts
+++ b/src/features/split-bill/presentation/useSplitBillListViewModel.ts
@@ -9,7 +9,7 @@ export function useSplitBillListViewModel() {
 
   const queryClient = useQueryClient();
 
-  const { data: bills = [], isLoading } = useQuery({
+  const { data: bills = [], isPending } = useQuery({
     queryKey: ['split-bills'],
     queryFn: async () => {
       const res = await fetchBills({});
@@ -17,5 +17,5 @@ export function useSplitBillListViewModel() {
     },
   });
 
-  return { bills, isLoading };
+  return { bills, isLoading: isPending };
 }

--- a/src/features/split-bill/presentation/useSplitBillManageViewModel.ts
+++ b/src/features/split-bill/presentation/useSplitBillManageViewModel.ts
@@ -12,7 +12,7 @@ export function useSplitBillManageViewModel(billId: string) {
   const queryClient = useQueryClient();
   const [error, setError] = useState<string | null>(null);
 
-  const { data: bill, isLoading } = useQuery({
+  const { data: bill, isPending: isLoading } = useQuery({
     queryKey: ['split-bill', billId],
     queryFn: async () => {
       const res = await fetchBill({ id: billId });

--- a/src/features/trips/presentation/state/useTripDetailViewModel.ts
+++ b/src/features/trips/presentation/state/useTripDetailViewModel.ts
@@ -21,7 +21,7 @@ export function useTripDetailViewModel(tripId: string) {
   const queryClient = useQueryClient();
   const [error, setError] = useState<string | null>(null);
 
-  const { data: tripDetail, isLoading } = useQuery({
+  const { data: tripDetail, isPending: isLoading } = useQuery({
     queryKey: ['trip', tripId],
     queryFn: async () => {
       const res = await fetchDetail({ tripId });

--- a/src/features/trips/presentation/state/useTripListViewModel.ts
+++ b/src/features/trips/presentation/state/useTripListViewModel.ts
@@ -12,7 +12,7 @@ export function useTripListViewModel() {
   const queryClient = useQueryClient();
   const [error, setError] = useState<string | null>(null);
 
-  const { data: trips = [], isLoading } = useQuery({
+  const { data: trips = [], isPending } = useQuery({
     queryKey: ['trips'],
     queryFn: async () => {
       const res = await fetchTrips({});
@@ -53,7 +53,7 @@ export function useTripListViewModel() {
 
   return {
     trips,
-    isLoading,
+    isLoading: isPending,
     isCreating,
     isDeleting,
     error,


### PR DESCRIPTION
## Summary

- Fixes skeleton loading not appearing in production (Vercel) on `/split-bill`, `/split-bill/[id]`, and `/split-bill/trips/[tripId]`
- Root cause: TanStack Query v5 `isLoading = isPending && isFetching` — during SSR no fetch is in-flight so `isFetching` is `false`, making `isLoading` always `false` in server-rendered HTML
- Fix: swap `isLoading` → `isPending` in all four affected viewmodels, and add `loading.tsx` route-segment files so Next.js App Router streams a skeleton before data arrives

## Changes

- `useSplitBillListViewModel.ts`, `useSplitBillManageViewModel.ts`, `useTripListViewModel.ts`, `useTripDetailViewModel.ts` — destructure `isPending: isLoading` from `useQuery`
- `src/app/(main)/split-bill/loading.tsx` — new route-segment skeleton (trips + standalone bills sections)
- `src/app/(main)/split-bill/[id]/loading.tsx` — new route-segment skeleton
- `src/app/(main)/split-bill/trips/[tripId]/loading.tsx` — new route-segment skeleton

## Test plan

- [ ] Deploy to Vercel preview and verify skeleton appears on `/split-bill` before data loads
- [ ] Verify skeleton appears on `/split-bill/[id]` before bill data loads
- [ ] Verify skeleton appears on `/split-bill/trips/[tripId]` before trip data loads
- [ ] Confirm localhost behavior unchanged

Closes #95

🤖 Generated with [Claude Code](https://claude.com/claude-code)