### PR TITLE
fix(skeleton): replace h-8/h-24 with inline styles on detail screens

### DIFF
--- a/issues/000-backlog.md
+++ b/issues/000-backlog.md
@@ -2,6 +2,7 @@
 
 | # | Title | Status | Link |
 |---|-------|--------|------|
+| 097 | fix(skeleton): h-24 purged by Tailwind v4 on split-bill detail and trip detail screens | `pending` | [#97](https://github.com/handharr-labs/xpnsio/issues/97) |
 | 095 | fix: skeleton loading missing for standalone bills section on split-bill page in production | `pending` | [#95](https://github.com/handharr-labs/xpnsio/issues/95) |
 | 093 | fix(split-bill): multiple UI bugs in new split bill flow | `pending` | [#93](https://github.com/handharr-labs/xpnsio/issues/93) |
 | 091 | fix(mobile): extend w-full skeleton fix to all remaining screens | `pending` | [#91](https://github.com/handharr-labs/xpnsio/issues/91) |

--- a/src/features/split-bill/presentation/SplitBillManageView.tsx
+++ b/src/features/split-bill/presentation/SplitBillManageView.tsx
@@ -31,9 +31,9 @@ export function SplitBillManageView({ billId }: { billId: string }) {
   if (isLoading) {
     return (
       <main className="px-4 pt-4 pb-8 max-w-lg mx-auto">
-        <div className="h-8 w-48 bg-muted rounded-xl animate-pulse mb-4" />
+        <div style={{ height: '2rem' }} className="w-48 bg-muted rounded-xl animate-pulse mb-4" />
         <div className="space-y-3">
-          {[1, 2, 3].map((i) => <div key={i} className="h-24 w-full rounded-2xl bg-muted animate-pulse" />)}
+          {[1, 2, 3].map((i) => <div key={i} style={{ height: '6rem' }} className="w-full rounded-2xl bg-muted animate-pulse" />)}
         </div>
       </main>
     );

--- a/src/features/trips/presentation/views/TripDetailView.tsx
+++ b/src/features/trips/presentation/views/TripDetailView.tsx
@@ -77,10 +77,10 @@ export function TripDetailView({ tripId }: { tripId: string }) {
   if (isLoading) {
     return (
       <main className="px-4 pt-4 pb-8 max-w-lg mx-auto">
-        <div className="h-8 w-48 bg-muted rounded-xl animate-pulse mb-4" />
+        <div style={{ height: '2rem' }} className="w-48 bg-muted rounded-xl animate-pulse mb-4" />
         <div className="space-y-3">
           {[1, 2, 3].map((i) => (
-            <div key={i} className="h-24 w-full rounded-2xl bg-muted animate-pulse" />
+            <div key={i} style={{ height: '6rem' }} className="w-full rounded-2xl bg-muted animate-pulse" />
           ))}
         </div>
       </main>


### PR DESCRIPTION
Closes #97

## Summary
- `SplitBillManageView` and `TripDetailView` skeleton blocks used `h-8` / `h-24` Tailwind classes that were unique to those files and purged by Tailwind v4's static PostCSS scanner in production
- Replaced with `style={{ height: '2rem' }}` / `style={{ height: '6rem' }}` — same fix applied to `SplitBillListView` and `TripListView` in #95 (commit `8e0adee`)

## Test plan
- [ ] Deploy to Vercel preview and visit `/split-bill/[id]` — confirm 3 skeleton bars visible before data loads
- [ ] Visit `/split-bill/trips/[id]` — confirm 3 skeleton bars visible before data loads
- [ ] Confirm dev behavior unchanged (still shows 3 bars)

🤖 Generated with [Claude Code](https://claude.com/claude-code)