### PR TITLE
fix(css): bypass --color-popover indirection for select dropdown in production #99

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -153,3 +153,15 @@
 .w-\(--anchor-width\)         { width: var(--anchor-width); }
 .max-h-\(--available-height\) { max-height: var(--available-height); }
 .origin-\(--transform-origin\) { transform-origin: var(--transform-origin); }
+
+/*
+ * `bg-popover` resolves through the @theme inline chain:
+ *   bg-popover → var(--color-popover) → var(--popover)
+ * Under webpack + LightningCSS the intermediate --color-popover variable can be
+ * optimised away, making the popup background transparent in production.
+ * Declare it directly on the data-slot attribute to guarantee it always renders.
+ */
+[data-slot="select-content"] {
+  background-color: var(--popover);
+  color: var(--popover-foreground);
+}


### PR DESCRIPTION
## Summary

- The Select dropdown on `/split-bill/new` (Adjustments step) rendered without a background in production (Webpack + `@tailwindcss/postcss`) while working correctly in dev (Turbopack)
- Root cause: `bg-popover` resolves through a two-level CSS variable chain (`bg-popover` → `var(--color-popover)` → `var(--popover)`); Webpack + LightningCSS can optimise away the intermediate `--color-popover` variable, leaving the popup background transparent
- Fix: adds `[data-slot="select-content"]` rule in `globals.css` using `var(--popover)` directly — the same established pattern used at lines 147–155 for other CSS variable shorthand classes

## Files changed

- `src/app/globals.css` — appended `[data-slot="select-content"]` rule after the existing `.origin-(--transform-origin)` workaround block

## Test plan

- [ ] Run `npm run build` and verify no CSS errors
- [ ] Open `/split-bill/new`, advance to Adjustments step, open a Select dropdown — background box must be visible in the production build
- [ ] Confirm dev (Turbopack) still works as before

Closes #99

🤖 Generated with [Claude Code](https://claude.com/claude-code)