### PR TITLE
fix: budget settings not persisted across periods — closes #101

### DIFF
--- a/.claude/agents/auto-feature-planner.md
+++ b/.claude/agents/auto-feature-planner.md
@@ -1,0 +1,1 @@
+../software-dev-agentic/lib/core/agents/builder/auto-feature-planner.md

--- a/.claude/agents/data-planner.md
+++ b/.claude/agents/data-planner.md
@@ -1,0 +1,1 @@
+../software-dev-agentic/lib/core/agents/builder/data-planner.md

--- a/.claude/agents/debug-log-worker.md
+++ b/.claude/agents/debug-log-worker.md
@@ -1,0 +1,1 @@
+../software-dev-agentic/lib/core/agents/detective/debug-log-worker.md

--- a/.claude/agents/domain-planner.md
+++ b/.claude/agents/domain-planner.md
@@ -1,0 +1,1 @@
+../software-dev-agentic/lib/core/agents/builder/domain-planner.md

--- a/.claude/agents/feature-worker.md
+++ b/.claude/agents/feature-worker.md
@@ -1,0 +1,1 @@
+../software-dev-agentic/lib/core/agents/builder/feature-worker.md

--- a/.claude/agents/pres-planner.md
+++ b/.claude/agents/pres-planner.md
@@ -1,0 +1,1 @@
+../software-dev-agentic/lib/core/agents/builder/pres-planner.md

--- a/.claude/agents/prompt-debug-worker.md
+++ b/.claude/agents/prompt-debug-worker.md
@@ -1,1 +1,0 @@
-../software-dev-agentic/lib/core/agents/detective/prompt-debug-worker.md

--- a/.claude/hooks/require-feature-orchestrator.sh
+++ b/.claude/hooks/require-feature-orchestrator.sh
@@ -1,1 +1,0 @@
-../software-dev-agentic/lib/core/hooks/require-feature-orchestrator.sh

--- a/.claude/reference/builder/data.md
+++ b/.claude/reference/builder/data.md
@@ -1,0 +1,1 @@
+../../software-dev-agentic/lib/core/reference/builder/data.md

--- a/.claude/reference/builder/di-containers.md
+++ b/.claude/reference/builder/di-containers.md
@@ -1,0 +1,1 @@
+../../software-dev-agentic/lib/core/reference/builder/di-containers.md

--- a/.claude/reference/builder/di.md
+++ b/.claude/reference/builder/di.md
@@ -1,0 +1,1 @@
+../../software-dev-agentic/lib/core/reference/builder/di.md

--- a/.claude/reference/builder/domain-purity.md
+++ b/.claude/reference/builder/domain-purity.md
@@ -1,0 +1,1 @@
+../../software-dev-agentic/lib/core/reference/builder/domain-purity.md

--- a/.claude/reference/builder/domain.md
+++ b/.claude/reference/builder/domain.md
@@ -1,0 +1,1 @@
+../../software-dev-agentic/lib/core/reference/builder/domain.md

--- a/.claude/reference/builder/error-handling.md
+++ b/.claude/reference/builder/error-handling.md
@@ -1,0 +1,1 @@
+../../software-dev-agentic/lib/core/reference/builder/error-handling.md

--- a/.claude/reference/builder/layer-contracts.md
+++ b/.claude/reference/builder/layer-contracts.md
@@ -1,0 +1,1 @@
+../../software-dev-agentic/lib/core/reference/builder/layer-contracts.md

--- a/.claude/reference/builder/presentation.md
+++ b/.claude/reference/builder/presentation.md
@@ -1,0 +1,1 @@
+../../software-dev-agentic/lib/core/reference/builder/presentation.md

--- a/.claude/reference/builder/testing.md
+++ b/.claude/reference/builder/testing.md
@@ -1,0 +1,1 @@
+../../software-dev-agentic/lib/core/reference/builder/testing.md

--- a/.claude/reference/builder/ui.md
+++ b/.claude/reference/builder/ui.md
@@ -1,0 +1,1 @@
+../../software-dev-agentic/lib/core/reference/builder/ui.md

--- a/.claude/reference/clean-arch/data.md
+++ b/.claude/reference/clean-arch/data.md
@@ -1,1 +1,0 @@
-../software-dev-agentic/lib/core/reference/clean-arch/data.md

--- a/.claude/reference/clean-arch/di-containers.md
+++ b/.claude/reference/clean-arch/di-containers.md
@@ -1,1 +1,0 @@
-../software-dev-agentic/lib/core/reference/clean-arch/di-containers.md

--- a/.claude/reference/clean-arch/di.md
+++ b/.claude/reference/clean-arch/di.md
@@ -1,1 +1,0 @@
-../software-dev-agentic/lib/core/reference/clean-arch/di.md

--- a/.claude/reference/clean-arch/domain-purity.md
+++ b/.claude/reference/clean-arch/domain-purity.md
@@ -1,1 +1,0 @@
-../software-dev-agentic/lib/core/reference/clean-arch/domain-purity.md

--- a/.claude/reference/clean-arch/domain.md
+++ b/.claude/reference/clean-arch/domain.md
@@ -1,1 +1,0 @@
-../software-dev-agentic/lib/core/reference/clean-arch/domain.md

--- a/.claude/reference/clean-arch/error-handling.md
+++ b/.claude/reference/clean-arch/error-handling.md
@@ -1,1 +1,0 @@
-../software-dev-agentic/lib/core/reference/clean-arch/error-handling.md

--- a/.claude/reference/clean-arch/layer-contracts.md
+++ b/.claude/reference/clean-arch/layer-contracts.md
@@ -1,1 +1,0 @@
-../software-dev-agentic/lib/core/reference/clean-arch/layer-contracts.md

--- a/.claude/reference/clean-arch/presentation.md
+++ b/.claude/reference/clean-arch/presentation.md
@@ -1,1 +1,0 @@
-../software-dev-agentic/lib/core/reference/clean-arch/presentation.md

--- a/.claude/reference/clean-arch/testing.md
+++ b/.claude/reference/clean-arch/testing.md
@@ -1,1 +1,0 @@
-../software-dev-agentic/lib/core/reference/clean-arch/testing.md

--- a/.claude/reference/clean-arch/ui.md
+++ b/.claude/reference/clean-arch/ui.md
@@ -1,1 +1,0 @@
-../software-dev-agentic/lib/core/reference/clean-arch/ui.md

--- a/.claude/reference/contract/builder/data.md
+++ b/.claude/reference/contract/builder/data.md
@@ -1,0 +1,1 @@
+../../../software-dev-agentic/lib/platforms/web/reference/contract/builder/data.md

--- a/.claude/reference/contract/builder/di.md
+++ b/.claude/reference/contract/builder/di.md
@@ -1,0 +1,1 @@
+../../../software-dev-agentic/lib/platforms/web/reference/contract/builder/di.md

--- a/.claude/reference/contract/builder/domain.md
+++ b/.claude/reference/contract/builder/domain.md
@@ -1,0 +1,1 @@
+../../../software-dev-agentic/lib/platforms/web/reference/contract/builder/domain.md

--- a/.claude/reference/contract/builder/error-handling.md
+++ b/.claude/reference/contract/builder/error-handling.md
@@ -1,0 +1,1 @@
+../../../software-dev-agentic/lib/platforms/web/reference/contract/builder/error-handling.md

--- a/.claude/reference/contract/builder/navigation.md
+++ b/.claude/reference/contract/builder/navigation.md
@@ -1,0 +1,1 @@
+../../../software-dev-agentic/lib/platforms/web/reference/contract/builder/navigation.md

--- a/.claude/reference/contract/builder/presentation.md
+++ b/.claude/reference/contract/builder/presentation.md
@@ -1,0 +1,1 @@
+../../../software-dev-agentic/lib/platforms/web/reference/contract/builder/presentation.md

--- a/.claude/reference/contract/builder/testing.md
+++ b/.claude/reference/contract/builder/testing.md
@@ -1,0 +1,1 @@
+../../../software-dev-agentic/lib/platforms/web/reference/contract/builder/testing.md

--- a/.claude/reference/contract/builder/utilities.md
+++ b/.claude/reference/contract/builder/utilities.md
@@ -1,0 +1,1 @@
+../../../software-dev-agentic/lib/platforms/web/reference/contract/builder/utilities.md

--- a/.claude/reference/contract/data.md
+++ b/.claude/reference/contract/data.md
@@ -1,1 +1,0 @@
-../software-dev-agentic/lib/platforms/web/reference/contract/data.md

--- a/.claude/reference/contract/di.md
+++ b/.claude/reference/contract/di.md
@@ -1,1 +1,0 @@
-../software-dev-agentic/lib/platforms/web/reference/contract/di.md

--- a/.claude/reference/contract/domain.md
+++ b/.claude/reference/contract/domain.md
@@ -1,1 +1,0 @@
-../software-dev-agentic/lib/platforms/web/reference/contract/domain.md

--- a/.claude/reference/contract/error-handling.md
+++ b/.claude/reference/contract/error-handling.md
@@ -1,1 +1,0 @@
-../software-dev-agentic/lib/platforms/web/reference/contract/error-handling.md

--- a/.claude/reference/contract/navigation.md
+++ b/.claude/reference/contract/navigation.md
@@ -1,1 +1,0 @@
-../software-dev-agentic/lib/platforms/web/reference/contract/navigation.md

--- a/.claude/reference/contract/presentation.md
+++ b/.claude/reference/contract/presentation.md
@@ -1,1 +1,0 @@
-../software-dev-agentic/lib/platforms/web/reference/contract/presentation.md

--- a/.claude/reference/contract/testing.md
+++ b/.claude/reference/contract/testing.md
@@ -1,1 +1,0 @@
-../software-dev-agentic/lib/platforms/web/reference/contract/testing.md

--- a/.claude/reference/contract/utilities.md
+++ b/.claude/reference/contract/utilities.md
@@ -1,1 +1,0 @@
-../software-dev-agentic/lib/platforms/web/reference/contract/utilities.md

--- a/.claude/reference/data.md
+++ b/.claude/reference/data.md
@@ -1,1 +1,0 @@
-../software-dev-agentic/lib/platforms/web/reference/data.md

--- a/.claude/reference/di-containers.md
+++ b/.claude/reference/di-containers.md
@@ -1,1 +1,0 @@
-../software-dev-agentic/lib/core/reference/clean-arch/di-containers.md

--- a/.claude/reference/di.md
+++ b/.claude/reference/di.md
@@ -1,1 +1,0 @@
-../software-dev-agentic/lib/platforms/web/reference/di.md

--- a/.claude/reference/domain-purity.md
+++ b/.claude/reference/domain-purity.md
@@ -1,1 +1,0 @@
-../software-dev-agentic/lib/core/reference/clean-arch/domain-purity.md

--- a/.claude/reference/domain.md
+++ b/.claude/reference/domain.md
@@ -1,1 +1,0 @@
-../software-dev-agentic/lib/platforms/web/reference/domain.md

--- a/.claude/reference/error-handling.md
+++ b/.claude/reference/error-handling.md
@@ -1,1 +1,0 @@
-../software-dev-agentic/lib/platforms/web/reference/error-handling.md

--- a/.claude/reference/layer-contracts.md
+++ b/.claude/reference/layer-contracts.md
@@ -1,1 +1,0 @@
-../software-dev-agentic/lib/core/reference/clean-arch/layer-contracts.md

--- a/.claude/reference/navigation.md
+++ b/.claude/reference/navigation.md
@@ -1,1 +1,0 @@
-../software-dev-agentic/lib/platforms/web/reference/navigation.md

--- a/.claude/reference/presentation.md
+++ b/.claude/reference/presentation.md
@@ -1,1 +1,0 @@
-../software-dev-agentic/lib/platforms/web/reference/presentation.md

--- a/.claude/reference/testing.md
+++ b/.claude/reference/testing.md
@@ -1,1 +1,0 @@
-../software-dev-agentic/lib/platforms/web/reference/testing.md

--- a/.claude/reference/utilities.md
+++ b/.claude/reference/utilities.md
@@ -1,1 +1,0 @@
-../software-dev-agentic/lib/platforms/web/reference/utilities.md

--- a/.claude/skills/arch-review
+++ b/.claude/skills/arch-review
@@ -1,0 +1,1 @@
+../software-dev-agentic/lib/core/skills/arch-review

--- a/.claude/skills/backend-orchestrator
+++ b/.claude/skills/backend-orchestrator
@@ -1,0 +1,1 @@
+../software-dev-agentic/lib/core/skills/backend-orchestrator

--- a/.claude/skills/build-from-ticket
+++ b/.claude/skills/build-from-ticket
@@ -1,0 +1,1 @@
+../software-dev-agentic/lib/core/skills/build-from-ticket

--- a/.claude/skills/data-create-datasource
+++ b/.claude/skills/data-create-datasource
@@ -1,1 +1,0 @@
-../software-dev-agentic/lib/platforms/web/skills/data-create-datasource

--- a/.claude/skills/data-create-mapper
+++ b/.claude/skills/data-create-mapper
@@ -1,1 +1,0 @@
-../software-dev-agentic/lib/platforms/web/skills/data-create-mapper

--- a/.claude/skills/data-create-repository-impl
+++ b/.claude/skills/data-create-repository-impl
@@ -1,1 +1,0 @@
-../software-dev-agentic/lib/platforms/web/skills/data-create-repository-impl

--- a/.claude/skills/data-update-mapper
+++ b/.claude/skills/data-update-mapper
@@ -1,1 +1,0 @@
-../software-dev-agentic/lib/platforms/web/skills/data-update-mapper

--- a/.claude/skills/debug-orchestrator
+++ b/.claude/skills/debug-orchestrator
@@ -1,0 +1,1 @@
+../software-dev-agentic/lib/core/skills/debug-orchestrator

--- a/.claude/skills/domain-create-entity
+++ b/.claude/skills/domain-create-entity
@@ -1,1 +1,0 @@
-../software-dev-agentic/lib/platforms/web/skills/domain-create-entity

--- a/.claude/skills/domain-create-repository
+++ b/.claude/skills/domain-create-repository
@@ -1,1 +1,0 @@
-../software-dev-agentic/lib/platforms/web/skills/domain-create-repository

--- a/.claude/skills/domain-create-service
+++ b/.claude/skills/domain-create-service
@@ -1,1 +1,0 @@
-../software-dev-agentic/lib/platforms/web/skills/domain-create-service

--- a/.claude/skills/domain-create-usecase
+++ b/.claude/skills/domain-create-usecase
@@ -1,1 +1,0 @@
-../software-dev-agentic/lib/platforms/web/skills/domain-create-usecase

--- a/.claude/skills/domain-update-usecase
+++ b/.claude/skills/domain-update-usecase
@@ -1,1 +1,0 @@
-../software-dev-agentic/lib/platforms/web/skills/domain-update-usecase

--- a/.claude/skills/feature-orchestrator
+++ b/.claude/skills/feature-orchestrator
@@ -1,0 +1,1 @@
+../software-dev-agentic/lib/core/skills/feature-orchestrator

--- a/.claude/skills/issue-worker
+++ b/.claude/skills/issue-worker
@@ -1,0 +1,1 @@
+../software-dev-agentic/lib/core/skills/issue-worker

--- a/.claude/skills/plan
+++ b/.claude/skills/plan
@@ -1,1 +1,0 @@
-../software-dev-agentic/lib/core/skills/plan

--- a/.claude/skills/plan-feature
+++ b/.claude/skills/plan-feature
@@ -1,0 +1,1 @@
+../software-dev-agentic/lib/core/skills/plan-feature

--- a/.claude/skills/pres-create-component
+++ b/.claude/skills/pres-create-component
@@ -1,1 +1,0 @@
-../software-dev-agentic/lib/platforms/web/skills/pres-create-component

--- a/.claude/skills/pres-create-screen
+++ b/.claude/skills/pres-create-screen
@@ -1,1 +1,0 @@
-../software-dev-agentic/lib/platforms/web/skills/pres-create-screen

--- a/.claude/skills/pres-create-stateholder
+++ b/.claude/skills/pres-create-stateholder
@@ -1,1 +1,0 @@
-../software-dev-agentic/lib/platforms/web/skills/pres-create-stateholder

--- a/.claude/skills/pres-update-screen
+++ b/.claude/skills/pres-update-screen
@@ -1,1 +1,0 @@
-../software-dev-agentic/lib/platforms/web/skills/pres-update-screen

--- a/.claude/skills/pres-update-stateholder
+++ b/.claude/skills/pres-update-stateholder
@@ -1,1 +1,0 @@
-../software-dev-agentic/lib/platforms/web/skills/pres-update-stateholder

--- a/.claude/skills/setup-worker
+++ b/.claude/skills/setup-worker
@@ -1,0 +1,1 @@
+../software-dev-agentic/lib/core/skills/setup-worker

--- a/.claude/skills/sync
+++ b/.claude/skills/sync
@@ -1,0 +1,1 @@
+../software-dev-agentic/lib/core/skills/sync

--- a/.claude/skills/test-create-data
+++ b/.claude/skills/test-create-data
@@ -1,1 +1,0 @@
-../software-dev-agentic/lib/platforms/web/skills/test-create-data

--- a/.claude/skills/test-create-domain
+++ b/.claude/skills/test-create-domain
@@ -1,1 +1,0 @@
-../software-dev-agentic/lib/platforms/web/skills/test-create-domain

--- a/.claude/skills/test-create-presentation
+++ b/.claude/skills/test-create-presentation
@@ -1,1 +1,0 @@
-../software-dev-agentic/lib/platforms/web/skills/test-create-presentation

--- a/.claude/skills/test-fix
+++ b/.claude/skills/test-fix
@@ -1,1 +1,0 @@
-../software-dev-agentic/lib/platforms/web/skills/test-fix

--- a/.claude/skills/test-update
+++ b/.claude/skills/test-update
@@ -1,1 +1,0 @@
-../software-dev-agentic/lib/platforms/web/skills/test-update

--- a/.claude/skills/tracker-adjust-ticket
+++ b/.claude/skills/tracker-adjust-ticket
@@ -1,0 +1,1 @@
+../software-dev-agentic/lib/core/skills/tracker-adjust-ticket

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,11 +25,9 @@ Clean Architecture · DRY · SOLID — apply to all new code.
 
 ## Workflow
 
-Agents: `feature-orchestrator` · `backend-orchestrator` · `debug-worker` · `test-worker` · `arch-review-worker` · `.claude/skills/`
+Use trigger skills as entry points — `/feature-orchestrator`, `/arch-review`, `/debug-orchestrator`, etc.
 
-**Feature work (create or update, any scope) → always delegate to `feature-orchestrator`, never inline.**
-
-**If the delegation guard hook blocks an edit → always stop and ask the user: inline or `feature-orchestrator`? Never resolve it autonomously.**
+**Feature work → always start with `/feature-orchestrator`, never inline.**
 
 ## Agent Spawning Rules
 
@@ -37,6 +35,19 @@ Agents: `feature-orchestrator` · `backend-orchestrator` · `debug-worker` · `t
 > Use Grep for all symbol and pattern discovery before deciding which files to Read. Only Read a file in full after Grep confirms it is the right target. Do not speculatively read large view or component files.
 
 Pass Explore output as a structured path list to the next agent — never raw file contents. This prevents duplicate reads in the receiving agent.
+
+## Stack
+
+Fill in your project's decisions here. Agents read this file every session — once filled, they pick up your choices automatically.
+
+| Concern | Decision |
+|---|---|
+| Backend type | <!-- local-db (Next.js owns the DB) / remote-api (external API you don't control) --> |
+| ORM | <!-- Prisma / Drizzle / Kysely / none --> |
+| Auth | <!-- NextAuth / Clerk / Lucia / Better Auth / none --> |
+| Styling | <!-- Tailwind+shadcn / Tailwind / Chakra / MUI / CSS Modules --> |
+| Testing | <!-- Vitest / Jest --> |
+| Deployment | <!-- Vercel / Docker / AWS --> |
 
 ## Known Configurations
 

--- a/issues/000-backlog.md
+++ b/issues/000-backlog.md
@@ -2,6 +2,7 @@
 
 | # | Title | Status | Link |
 |---|-------|--------|------|
+| 101 | fix: budget settings not persisted across periods — deleted instead of carried forward | `pending` | [#101](https://github.com/handharr-labs/xpnsio/issues/101) |
 | 097 | fix(skeleton): h-24 purged by Tailwind v4 on split-bill detail and trip detail screens | `pending` | [#97](https://github.com/handharr-labs/xpnsio/issues/97) |
 | 095 | fix: skeleton loading missing for standalone bills section on split-bill page in production | `pending` | [#95](https://github.com/handharr-labs/xpnsio/issues/95) |
 | 093 | fix(split-bill): multiple UI bugs in new split bill flow | `pending` | [#93](https://github.com/handharr-labs/xpnsio/issues/93) |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "xpnsio",
-  "version": "2.8.0",
+  "version": "2.10.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "xpnsio",
-      "version": "2.8.0",
+      "version": "2.10.0",
       "dependencies": {
         "@base-ui/react": "^1.2.0",
         "@ducanh2912/next-pwa": "10.2.9",
@@ -121,7 +121,6 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -1874,7 +1873,6 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -4442,7 +4440,6 @@
       "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-1.3.0.tgz",
       "integrity": "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "^14.21.3 || >=16"
       },
@@ -4548,7 +4545,6 @@
       "integrity": "sha512-DhGl4xMVFGVIyMwswXeyzdL4uXD5OGILGX5N8Y+f6W7LhC1Ze2poSNrkF/fedpVDHEEZ+PHFW0vL14I+mm8K3Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^6.0.0",
         "@octokit/graphql": "^9.0.3",
@@ -5487,7 +5483,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5501,7 +5496,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5515,7 +5509,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5529,7 +5522,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5543,7 +5535,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5557,7 +5548,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5571,7 +5561,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5585,7 +5574,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5599,7 +5587,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5613,7 +5600,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5627,7 +5613,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5641,7 +5626,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5655,7 +5639,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5669,7 +5652,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5683,7 +5665,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5697,7 +5678,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5711,7 +5691,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5725,7 +5704,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5739,7 +5717,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5753,7 +5730,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5767,7 +5743,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5781,7 +5756,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5795,7 +5769,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5809,7 +5782,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5823,7 +5795,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5992,7 +5963,6 @@
       "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.98.0.tgz",
       "integrity": "sha512-Ohc97CtInLwZyiSASz7tT9/Abm/vqnIbO9REp+PivVUII8UZsuI3bngRQnYgJdFoOIwvaEII1fX1qy8x0CyNiw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@supabase/auth-js": "2.98.0",
         "@supabase/functions-js": "2.98.0",
@@ -6337,6 +6307,7 @@
       "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
@@ -6357,6 +6328,7 @@
       "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "dequal": "^2.0.3"
       }
@@ -6524,7 +6496,8 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -6532,7 +6505,6 @@
       "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/parser": "^7.20.7",
         "@babel/types": "^7.20.7",
@@ -6595,6 +6567,7 @@
       "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-9.6.1.tgz",
       "integrity": "sha512-FXx2pKgId/WyYo2jXw63kk7/+TY7u7AziEJxJAnSFzHlqTAS3Ync6SvgYAN/k4/PQpnnVuzoMuVnByKK2qp0ag==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/estree": "*",
         "@types/json-schema": "*"
@@ -6605,6 +6578,7 @@
       "resolved": "https://registry.npmjs.org/@types/eslint-scope/-/eslint-scope-3.7.7.tgz",
       "integrity": "sha512-MzMFlSLBqNF2gcHWO0G1vP/YQyfvrxZ0bF+u7mzUdZ1/xK4A4sru+nraZz5i3iEIk1l1uyicaDVTB4QbbEkAYg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/eslint": "*",
         "@types/estree": "*"
@@ -6664,7 +6638,6 @@
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -6675,7 +6648,6 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -6758,7 +6730,6 @@
       "integrity": "sha512-klQbnPAAiGYFyI02+znpBRLyjL4/BrBd0nyWkdC0s/6xFLkXYQ8OoRrSkqacS1ddVxf/LDyODIKbQ5TgKAf/Fg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.56.1",
         "@typescript-eslint/types": "8.56.1",
@@ -10605,6 +10576,7 @@
       "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.14.1.tgz",
       "integrity": "sha512-nuBEDgQfm1ccRp/8bCQrx1frohyufl4JlbMMZ4P1wpeOfDhF6FQkxZJ1b/e+PLwr6X1Nhw6OLme5usuBWYBvuQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@webassemblyjs/helper-numbers": "1.13.2",
         "@webassemblyjs/helper-wasm-bytecode": "1.13.2"
@@ -10614,25 +10586,29 @@
       "version": "1.13.2",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.13.2.tgz",
       "integrity": "sha512-6oXyTOzbKxGH4steLbLNOu71Oj+C8Lg34n6CqRvqfS2O71BxY6ByfMDRhBytzknj9yGUPVJ1qIKhRlAwO1AovA==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@webassemblyjs/helper-api-error": {
       "version": "1.13.2",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-api-error/-/helper-api-error-1.13.2.tgz",
       "integrity": "sha512-U56GMYxy4ZQCbDZd6JuvvNV/WFildOjsaWD3Tzzvmw/mas3cXzRJPMjP83JqEsgSbyrmaGjBfDtV7KDXV9UzFQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@webassemblyjs/helper-buffer": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.14.1.tgz",
       "integrity": "sha512-jyH7wtcHiKssDtFPRB+iQdxlDf96m0E39yb0k5uJVhFGleZFoNw1c4aeIcVUPPbXUVJ94wwnMOAqUHyzoEPVMA==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@webassemblyjs/helper-numbers": {
       "version": "1.13.2",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-numbers/-/helper-numbers-1.13.2.tgz",
       "integrity": "sha512-FE8aCmS5Q6eQYcV3gI35O4J789wlQA+7JrqTTpJqn5emA4U2hvwJmvFRC0HODS+3Ye6WioDklgd6scJ3+PLnEA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@webassemblyjs/floating-point-hex-parser": "1.13.2",
         "@webassemblyjs/helper-api-error": "1.13.2",
@@ -10643,13 +10619,15 @@
       "version": "1.13.2",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.13.2.tgz",
       "integrity": "sha512-3QbLKy93F0EAIXLh0ogEVR6rOubA9AoZ+WRYhNbFyuB70j3dRdwH9g+qXhLAO0kiYGlg3TxDV+I4rQTr/YNXkA==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@webassemblyjs/helper-wasm-section": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.14.1.tgz",
       "integrity": "sha512-ds5mXEqTJ6oxRoqjhWDU83OgzAYjwsCV8Lo/N+oRsNDmx/ZDpqalmrtgOMkHwxsG0iI//3BwWAErYRHtgn0dZw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@webassemblyjs/ast": "1.14.1",
         "@webassemblyjs/helper-buffer": "1.14.1",
@@ -10662,6 +10640,7 @@
       "resolved": "https://registry.npmjs.org/@webassemblyjs/ieee754/-/ieee754-1.13.2.tgz",
       "integrity": "sha512-4LtOzh58S/5lX4ITKxnAK2USuNEvpdVV9AlgGQb8rJDHaLeHciwG4zlGr0j/SNWlr7x3vO1lDEsuePvtcDNCkw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@xtuc/ieee754": "^1.2.0"
       }
@@ -10671,6 +10650,7 @@
       "resolved": "https://registry.npmjs.org/@webassemblyjs/leb128/-/leb128-1.13.2.tgz",
       "integrity": "sha512-Lde1oNoIdzVzdkNEAWZ1dZ5orIbff80YPdHx20mrHwHrVNNTjNr8E3xz9BdpcGqRQbAEa+fkrCb+fRFTl/6sQw==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@xtuc/long": "4.2.2"
       }
@@ -10679,13 +10659,15 @@
       "version": "1.13.2",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/utf8/-/utf8-1.13.2.tgz",
       "integrity": "sha512-3NQWGjKTASY1xV5m7Hr0iPeXD9+RDobLll3T9d2AO+g3my8xy5peVyjSag4I50mR1bBSN/Ct12lo+R9tJk0NZQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@webassemblyjs/wasm-edit": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-edit/-/wasm-edit-1.14.1.tgz",
       "integrity": "sha512-RNJUIQH/J8iA/1NzlE4N7KtyZNHi3w7at7hDjvRNm5rcUXa00z1vRz3glZoULfJ5mpvYhLybmVcwcjGrC1pRrQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@webassemblyjs/ast": "1.14.1",
         "@webassemblyjs/helper-buffer": "1.14.1",
@@ -10702,6 +10684,7 @@
       "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-gen/-/wasm-gen-1.14.1.tgz",
       "integrity": "sha512-AmomSIjP8ZbfGQhumkNvgC33AY7qtMCXnN6bL2u2Js4gVCg8fp735aEiMSBbDR7UQIj90n4wKAFUSEd0QN2Ukg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@webassemblyjs/ast": "1.14.1",
         "@webassemblyjs/helper-wasm-bytecode": "1.13.2",
@@ -10715,6 +10698,7 @@
       "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-opt/-/wasm-opt-1.14.1.tgz",
       "integrity": "sha512-PTcKLUNvBqnY2U6E5bdOQcSM+oVP/PmrDY9NzowJjislEjwP/C4an2303MCVS2Mg9d3AJpIGdUFIQQWbPds0Sw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@webassemblyjs/ast": "1.14.1",
         "@webassemblyjs/helper-buffer": "1.14.1",
@@ -10727,6 +10711,7 @@
       "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.14.1.tgz",
       "integrity": "sha512-JLBl+KZ0R5qB7mCnud/yyX08jWFw5MsoalJ1pQ4EdFlgj9VdXKGuENGsiCIjegI1W7p91rUlcB/LB5yRJKNTcQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@webassemblyjs/ast": "1.14.1",
         "@webassemblyjs/helper-api-error": "1.13.2",
@@ -10741,6 +10726,7 @@
       "resolved": "https://registry.npmjs.org/@webassemblyjs/wast-printer/-/wast-printer-1.14.1.tgz",
       "integrity": "sha512-kPSSXE6De1XOR820C90RIo2ogvZG+c3KiHzqUoO/F34Y2shGzesfqv7o57xrxovZJH/MetF5UjroJ/R/3isoiw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@webassemblyjs/ast": "1.14.1",
         "@xtuc/long": "4.2.2"
@@ -10750,13 +10736,15 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
       "integrity": "sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==",
-      "license": "BSD-3-Clause"
+      "license": "BSD-3-Clause",
+      "peer": true
     },
     "node_modules/@xtuc/long": {
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/@xtuc/long/-/long-4.2.2.tgz",
       "integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==",
-      "license": "Apache-2.0"
+      "license": "Apache-2.0",
+      "peer": true
     },
     "node_modules/abbrev": {
       "version": "3.0.1",
@@ -10811,7 +10799,6 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -10834,6 +10821,7 @@
       "resolved": "https://registry.npmjs.org/acorn-import-phases/-/acorn-import-phases-1.0.4.tgz",
       "integrity": "sha512-wKmbr/DDiIXzEOiWrTTUcDm24kQ2vGfZQvM2fwg2vXqR5uW6aapr7ObPtj1th32b9u90/Pf4AItvdTh42fBmVQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10.13.0"
       },
@@ -11257,7 +11245,6 @@
       "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.6.tgz",
       "integrity": "sha512-ChTCHMouEe2kn713WHbQGcuYrr6fXTBiu460OTwWrWob16g1bXn4vtz07Ope7ewMozJAnEquLk5lWQWtBig9DQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "follow-redirects": "^1.15.11",
         "form-data": "^4.0.5",
@@ -11435,7 +11422,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -11690,6 +11676,7 @@
       "resolved": "https://registry.npmjs.org/chrome-trace-event/-/chrome-trace-event-1.0.4.tgz",
       "integrity": "sha512-rNjApaLzuwaOTjCiT8lSDdGN1APCiqkChLMJxJPWLunPAt5fy8xgU9/jNOchV84wfIxrA0lRQB7oCT8jrn/wrQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=6.0"
       }
@@ -12525,6 +12512,7 @@
       "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -12573,7 +12561,8 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/dot-prop": {
       "version": "5.3.0",
@@ -13141,7 +13130,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -13246,7 +13234,6 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -13432,7 +13419,6 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -13719,6 +13705,7 @@
       "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
       "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.8.x"
       }
@@ -14576,7 +14563,8 @@
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
       "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
-      "license": "BSD-2-Clause"
+      "license": "BSD-2-Clause",
+      "peer": true
     },
     "node_modules/globals": {
       "version": "14.0.0",
@@ -14771,7 +14759,6 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.5.tgz",
       "integrity": "sha512-3qq+FUBtlTHhtYxbxheZgY8NIFnkkC/MR8u5TTsr7YZ3wixryQ3cCwn3iZbg8p8B88iDBBAYSfZDS75t8MN7Vg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -15674,6 +15661,7 @@
       "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-27.5.1.tgz",
       "integrity": "sha512-7vuh85V5cdDofPyxn58nrPjBktZo0u9x1g8WtjQol+jZDaE+fhN+cIvTj11GndBnMnyfrUOG1sZQxCdjKh+DKg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/node": "*",
         "merge-stream": "^2.0.0",
@@ -15688,6 +15676,7 @@
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
       "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "has-flag": "^4.0.0"
       },
@@ -16187,6 +16176,7 @@
       "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.3.1.tgz",
       "integrity": "sha512-IWqP2SCPhyVFTBtRcgMHdzlf9ul25NwaFx4wCEH/KjAXuuHY4yNjvPXsBokp8jCB936PyWRaPKUNh8NvylLp2Q==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=6.11.5"
       },
@@ -16358,6 +16348,7 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -16855,7 +16846,6 @@
       "resolved": "https://registry.npmjs.org/next/-/next-16.1.6.tgz",
       "integrity": "sha512-hkyRkcu5x/41KoqnROkfTm2pZVbKxvbZRuNvKXLRXxs3VfyO0WhY50TQS40EuKO9SW3rBj/sF3WbVwDACeMZyw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@next/env": "16.1.6",
         "@swc/helpers": "0.5.15",
@@ -17861,7 +17851,6 @@
       "resolved": "https://registry.npmjs.org/postgres/-/postgres-3.4.8.tgz",
       "integrity": "sha512-d+JFcLM17njZaOLkv6SCev7uoLaBtfK86vMUXhW1Z4glPWh4jozno9APvW/XKFJ3CCxVoC7OL38BqRydtu5nGg==",
       "license": "Unlicense",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -17910,6 +17899,7 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -17925,6 +17915,7 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -17937,7 +17928,8 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/pretty-ms": {
       "version": "9.3.0",
@@ -18146,7 +18138,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.3.tgz",
       "integrity": "sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -18156,7 +18147,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -18351,7 +18341,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@nodeutils/defaults-deep": "1.1.0",
         "@octokit/rest": "22.0.1",
@@ -18733,7 +18722,6 @@
       "integrity": "sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -18944,6 +18932,7 @@
       "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.3.3.tgz",
       "integrity": "sha512-eflK8wEtyOE6+hsaRVPxvUKYCpRgzLqDTb8krvAsRIwOGlHoSgYLgBXoubGgLd2fT41/OUYdb48v4k4WWHQurA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/json-schema": "^7.0.9",
         "ajv": "^8.9.0",
@@ -18980,6 +18969,7 @@
       "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
       "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ajv": "^8.0.0"
       },
@@ -18997,6 +18987,7 @@
       "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-5.1.0.tgz",
       "integrity": "sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3"
       },
@@ -19008,7 +18999,8 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/semver": {
       "version": "6.3.1",
@@ -20115,6 +20107,7 @@
       "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.17.tgz",
       "integrity": "sha512-YR7PtUp6GMU91BgSJmlaX/rS2lGDbAF7D+Wtq7hRO+MiljNmodYvqslzCFiYVAgW+Qoaaia/QUIP4lGXufjdZw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jridgewell/trace-mapping": "^0.3.25",
         "jest-worker": "^27.4.5",
@@ -20241,7 +20234,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -21058,7 +21050,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -21927,7 +21918,6 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -22505,7 +22495,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -22619,6 +22608,7 @@
       "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.5.1.tgz",
       "integrity": "sha512-Zn5uXdcFNIA1+1Ei5McRd+iRzfhENPCe7LeABkJtNulSxjma+l7ltNx55BWZkRlwRnpOgHqxnjyaDgJnNXnqzg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "glob-to-regexp": "^0.4.1",
         "graceful-fs": "^4.1.2"
@@ -22654,6 +22644,7 @@
       "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.105.4.tgz",
       "integrity": "sha512-jTywjboN9aHxFlToqb0K0Zs9SbBoW4zRUlGzI2tYNxVYcEi/IPpn+Xi4ye5jTLvX2YeLuic/IvxNot+Q1jMoOw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.8",
@@ -22702,6 +22693,7 @@
       "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.3.4.tgz",
       "integrity": "sha512-7tP1PdV4vF+lYPnkMR0jMY5/la2ub5Fc/8VQrrU+lXkiM6C4TjVfGw7iKfyhnTQOsD+6Q/iKw0eFciziRgD58Q==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10.13.0"
       }
@@ -22710,13 +22702,15 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.0.0.tgz",
       "integrity": "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/webpack/node_modules/eslint-scope": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
       "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
       "license": "BSD-2-Clause",
+      "peer": true,
       "dependencies": {
         "esrecurse": "^4.3.0",
         "estraverse": "^4.1.1"
@@ -22730,6 +22724,7 @@
       "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
       "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
       "license": "BSD-2-Clause",
+      "peer": true,
       "engines": {
         "node": ">=4.0"
       }
@@ -23181,7 +23176,6 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
       "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -23252,7 +23246,6 @@
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.80.0.tgz",
       "integrity": "sha512-cIFJOD1DESzpjOBl763Kp1AH7UE/0fcdHe6rZXUdQ9c50uvgigvW97u3IcSeBwOkgqL/PXPBktBCh0KEu5L8XQ==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "rollup": "dist/bin/rollup"
       },
@@ -23504,7 +23497,6 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
       "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -23575,7 +23567,6 @@
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.80.0.tgz",
       "integrity": "sha512-cIFJOD1DESzpjOBl763Kp1AH7UE/0fcdHe6rZXUdQ9c50uvgigvW97u3IcSeBwOkgqL/PXPBktBCh0KEu5L8XQ==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "rollup": "dist/bin/rollup"
       },
@@ -23950,7 +23941,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/src/features/budget-settings/presentation/BudgetSettingEditView.tsx
+++ b/src/features/budget-settings/presentation/BudgetSettingEditView.tsx
@@ -128,7 +128,7 @@ export function BudgetSettingEditView({ id }: { id: string }) {
               )}
 
               {items.map((item, index) => (
-                <div key={item.id ?? index} className="space-y-2 rounded-lg border p-3">
+                <div key={index} className="space-y-2 rounded-lg border p-3">
                   {removingIndex === index ? (
                     <div className="flex items-center gap-2 rounded-md bg-red-500/10 ring-1 ring-red-500/20 px-3 py-2">
                       <span className="flex-1 text-sm text-red-700 dark:text-red-400">Remove this category?</span>

--- a/src/features/budget-settings/presentation/BudgetSettingsView.tsx
+++ b/src/features/budget-settings/presentation/BudgetSettingsView.tsx
@@ -20,14 +20,22 @@ export function BudgetSettingsView() {
 
   const handleApply = async (id: string) => {
     const now = new Date();
+    const setting = budgetSettings.find((s) => s.id === id);
+    const starterDay = setting?.starterDay ?? 1;
+    // If today is on or past the starterDay, we've rolled into the next billing period.
+    const calendarMonth = now.getMonth() + 1;
+    const calendarYear = now.getFullYear();
+    const isInNextPeriod = now.getDate() >= starterDay;
+    const month = isInNextPeriod ? (calendarMonth === 12 ? 1 : calendarMonth + 1) : calendarMonth;
+    const year = isInNextPeriod && calendarMonth === 12 ? calendarYear + 1 : calendarYear;
     setApplyingId(id);
     setActionError(null);
     setApplySuccessId(null);
     try {
       await applyBudgetSetting({
         budgetSettingId: id,
-        year: now.getFullYear(),
-        month: now.getMonth() + 1,
+        year,
+        month,
       });
       setApplySuccessId(id);
       setTimeout(() => setApplySuccessId(null), 3000);

--- a/src/features/budget-settings/presentation/useBudgetSettingEditViewModel.ts
+++ b/src/features/budget-settings/presentation/useBudgetSettingEditViewModel.ts
@@ -112,7 +112,7 @@ export function useBudgetSettingEditViewModel(budgetSettingId: string) {
   const addItem = () => {
     setItems((prev) => [
       ...prev,
-      { id: crypto.randomUUID(), name: '', masterCategory: 'monthly', color: '#6366f1', icon: 'circle', monthlyAmount: 0 },
+      { id: undefined, name: '', masterCategory: 'monthly', color: '#6366f1', icon: 'circle', monthlyAmount: 0 },
     ]);
   };
 

--- a/src/features/dashboard/domain/use-cases/dashboard/SyncBudgetForPeriodUseCase.ts
+++ b/src/features/dashboard/domain/use-cases/dashboard/SyncBudgetForPeriodUseCase.ts
@@ -18,14 +18,16 @@ export class SyncBudgetForPeriodUseCaseImpl implements SyncBudgetForPeriodUseCas
   ) {}
 
   async execute({ userId, year, month }: SyncBudgetForPeriodParams): Promise<void> {
+    // If this period already has an application, its budgets are authoritative — never overwrite.
+    const existingApp = await this.budgetRepository.getApplication(userId, year, month);
+    if (existingApp) return;
+
+    // No application for this period yet — carry forward from the most recent one.
     const lastApp = await this.budgetRepository.getLastApplication(userId);
     if (!lastApp) return;
 
     const setting = await this.budgetSettingRepository.getById(lastApp.budgetSettingId);
     if (!setting) return;
-
-    const budgets = await this.budgetRepository.getByMonth(userId, year, month);
-    if (budgets.length === setting.items.length) return;
 
     const items = setting.items.map((item) => ({
       categoryId: item.categoryId,

--- a/src/features/dashboard/domain/use-cases/dashboard/__tests__/SyncBudgetForPeriodUseCase.test.ts
+++ b/src/features/dashboard/domain/use-cases/dashboard/__tests__/SyncBudgetForPeriodUseCase.test.ts
@@ -1,0 +1,150 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { SyncBudgetForPeriodUseCaseImpl } from '../SyncBudgetForPeriodUseCase';
+import type { BudgetRepository } from '@/features/budget-settings/domain/repositories/BudgetRepository';
+import type { BudgetSettingRepository } from '@/features/budget-settings/domain/repositories/BudgetSettingRepository';
+import type { MonthlyBudgetApplication } from '@/features/budget-settings/domain/entities/Budget';
+import type { BudgetSetting } from '@/features/budget-settings/domain/entities/BudgetSetting';
+
+// ─── Fixtures ────────────────────────────────────────────────────────────────
+
+const USER_ID = 'user-abc';
+const YEAR = 2026;
+const MONTH = 4;
+
+const makeApplication = (overrides?: Partial<MonthlyBudgetApplication>): MonthlyBudgetApplication => ({
+  id: 'app-1',
+  userId: USER_ID,
+  budgetSettingId: 'setting-1',
+  year: YEAR,
+  month: MONTH,
+  ...overrides,
+});
+
+const makeSetting = (overrides?: Partial<BudgetSetting>): BudgetSetting => ({
+  id: 'setting-1',
+  userId: USER_ID,
+  name: 'Default',
+  totalMonthlyBudget: 5000000,
+  currency: 'IDR',
+  starterDay: 1,
+  createdAt: new Date('2026-01-01'),
+  items: [
+    {
+      id: 'item-1',
+      budgetSettingId: 'setting-1',
+      categoryId: 'cat-food',
+      categoryName: 'Food',
+      masterCategory: 'daily',
+      monthlyAmount: 1500000,
+    },
+  ],
+  ...overrides,
+});
+
+// ─── Mock factories ───────────────────────────────────────────────────────────
+
+const makeBudgetRepository = (): BudgetRepository => ({
+  getByMonth: vi.fn(),
+  upsertMany: vi.fn(),
+  getApplication: vi.fn(),
+  getLastApplication: vi.fn(),
+  applyBudgetSetting: vi.fn().mockResolvedValue(undefined),
+});
+
+const makeBudgetSettingRepository = (): BudgetSettingRepository => ({
+  getByUser: vi.fn(),
+  getById: vi.fn(),
+  create: vi.fn(),
+  update: vi.fn(),
+  delete: vi.fn(),
+});
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe('SyncBudgetForPeriodUseCaseImpl', () => {
+  let budgetRepo: BudgetRepository;
+  let budgetSettingRepo: BudgetSettingRepository;
+  let useCase: SyncBudgetForPeriodUseCaseImpl;
+
+  beforeEach(() => {
+    budgetRepo = makeBudgetRepository();
+    budgetSettingRepo = makeBudgetSettingRepository();
+    useCase = new SyncBudgetForPeriodUseCaseImpl(budgetRepo, budgetSettingRepo);
+  });
+
+  // ── Case 1: period rolls over — no existing application ──────────────────
+
+  describe('when no application exists for the current period', () => {
+    it('carries forward budgets from the last application and writes a new application', async () => {
+      const lastApp = makeApplication({ id: 'app-prev', year: YEAR, month: MONTH - 1 });
+      const setting = makeSetting();
+
+      vi.mocked(budgetRepo.getApplication).mockResolvedValue(null);
+      vi.mocked(budgetRepo.getLastApplication).mockResolvedValue(lastApp);
+      vi.mocked(budgetSettingRepo.getById).mockResolvedValue(setting);
+
+      await useCase.execute({ userId: USER_ID, year: YEAR, month: MONTH });
+
+      expect(budgetRepo.getApplication).toHaveBeenCalledWith(USER_ID, YEAR, MONTH);
+      expect(budgetRepo.getLastApplication).toHaveBeenCalledWith(USER_ID);
+      expect(budgetSettingRepo.getById).toHaveBeenCalledWith(lastApp.budgetSettingId);
+      expect(budgetRepo.applyBudgetSetting).toHaveBeenCalledOnce();
+      expect(budgetRepo.applyBudgetSetting).toHaveBeenCalledWith(
+        USER_ID,
+        lastApp.budgetSettingId,
+        [{ categoryId: 'cat-food', monthlyAmount: '1500000' }],
+        YEAR,
+        MONTH
+      );
+    });
+  });
+
+  // ── Case 2: period already applied — budgets must not be touched ─────────
+
+  describe('when an application already exists for the current period', () => {
+    it('returns early without writing any budgets or a new application', async () => {
+      vi.mocked(budgetRepo.getApplication).mockResolvedValue(makeApplication());
+
+      await useCase.execute({ userId: USER_ID, year: YEAR, month: MONTH });
+
+      expect(budgetRepo.getApplication).toHaveBeenCalledWith(USER_ID, YEAR, MONTH);
+      expect(budgetRepo.getLastApplication).not.toHaveBeenCalled();
+      expect(budgetSettingRepo.getById).not.toHaveBeenCalled();
+      expect(budgetRepo.applyBudgetSetting).not.toHaveBeenCalled();
+    });
+  });
+
+  // ── Edge case: first-time user, no last application ──────────────────────
+
+  describe('when no application exists for this period and there is no last application', () => {
+    it('does not crash and does not write anything', async () => {
+      vi.mocked(budgetRepo.getApplication).mockResolvedValue(null);
+      vi.mocked(budgetRepo.getLastApplication).mockResolvedValue(null);
+
+      await expect(
+        useCase.execute({ userId: USER_ID, year: YEAR, month: MONTH })
+      ).resolves.toBeUndefined();
+
+      expect(budgetRepo.applyBudgetSetting).not.toHaveBeenCalled();
+      expect(budgetSettingRepo.getById).not.toHaveBeenCalled();
+    });
+  });
+
+  // ── Edge case: last application references a missing budget setting ───────
+
+  describe('when getLastApplication returns an application but getById returns null', () => {
+    it('does not crash and does not write anything', async () => {
+      const lastApp = makeApplication({ id: 'app-prev' });
+
+      vi.mocked(budgetRepo.getApplication).mockResolvedValue(null);
+      vi.mocked(budgetRepo.getLastApplication).mockResolvedValue(lastApp);
+      vi.mocked(budgetSettingRepo.getById).mockResolvedValue(null);
+
+      await expect(
+        useCase.execute({ userId: USER_ID, year: YEAR, month: MONTH })
+      ).resolves.toBeUndefined();
+
+      expect(budgetRepo.applyBudgetSetting).not.toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- **Core fix:** `SyncBudgetForPeriodUseCase` now guards on the period application row — if it exists for the requested month/year, returns immediately. Only new periods (no application yet) are seeded from the most recent one. Prevents past/current budgets from being silently overwritten when a setting is edited.
- **Fix:** "Apply to This Month" now derives the correct billing period from the setting's `starterDay` — when today >= starterDay, the active period is already month+1.
- **Fix:** `addItem()` in the edit ViewModel was setting `id: crypto.randomUUID()` on new items, routing them to `updateCategoryAction` with a non-existent UUID instead of `createCategoryAction`. New items now have `id: undefined`.
- **Tests:** 4 unit tests added for `SyncBudgetForPeriodUseCaseImpl` covering both persistence cases and edge cases.

## Test plan

- [ ] Budget settings persist when period rolls over (no manual action needed)
- [ ] Editing a budget setting does not affect current/past period budgets
- [ ] "Apply to This Month" correctly targets the active billing period when `starterDay` has passed
- [ ] Adding a new category in the edit page creates it and saves it to the setting
- [ ] `npx vitest run src/features/dashboard/domain/use-cases/dashboard/__tests__/SyncBudgetForPeriodUseCase.test.ts` passes (4/4)

Closes #101

🤖 Generated with [Claude Code](https://claude.com/claude-code)